### PR TITLE
feat: use framework package overrides

### DIFF
--- a/examples/angular/src/main.ts
+++ b/examples/angular/src/main.ts
@@ -1,9 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { initFrameworkImport } from '@unuse/angular';
 import { App } from './app/app';
 import { appConfig } from './app/app.config';
 
-initFrameworkImport('angular')
-  .then(() => bootstrapApplication(App, appConfig))
-  // eslint-disable-next-line unicorn/prefer-top-level-await
-  .catch((error: unknown) => console.error(error));
+bootstrapApplication(App, appConfig);

--- a/examples/react/src/main.tsx
+++ b/examples/react/src/main.tsx
@@ -1,4 +1,3 @@
-import { initFrameworkImport } from '@unuse/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
@@ -7,15 +6,8 @@ const root = document.querySelector('#root');
 
 const app = createRoot(root as HTMLElement);
 
-initFrameworkImport('react')
-  .then(() => {
-    app.render(
-      <StrictMode>
-        <App />
-      </StrictMode>
-    );
-  })
-  // eslint-disable-next-line unicorn/prefer-top-level-await
-  .catch((error: unknown) => {
-    console.error('Failed to initialize framework import:', error);
-  });
+app.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/examples/solid/src/index.tsx
+++ b/examples/solid/src/index.tsx
@@ -1,4 +1,3 @@
-import { initFrameworkImport } from '@unuse/solid';
 import { render } from 'solid-js/web';
 import App from './App';
 
@@ -10,11 +9,4 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
   );
 }
 
-initFrameworkImport('solid')
-  .then(() => {
-    render(() => <App />, root as HTMLElement);
-  })
-  // eslint-disable-next-line unicorn/prefer-top-level-await
-  .catch((error: unknown) => {
-    console.error('Failed to initialize framework import:', error);
-  });
+render(() => <App />, root as HTMLElement);

--- a/examples/vue/src/main.ts
+++ b/examples/vue/src/main.ts
@@ -1,14 +1,6 @@
-import { initFrameworkImport } from '@unuse/vue';
 import { createApp } from 'vue';
 import App from './App.vue';
 
 const app = createApp(App);
 
-initFrameworkImport('vue')
-  .then(() => {
-    app.mount('#app');
-  })
-  // eslint-disable-next-line unicorn/prefer-top-level-await
-  .catch((error: unknown) => {
-    console.error('Failed to initialize framework import:', error);
-  });
+app.mount('#app');

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -27,6 +27,7 @@
     "dist"
   ],
   "dependencies": {
+    "alien-signals": "2.0.5",
     "unuse": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,3 +1,29 @@
+/* eslint-disable import-x/export */
+import type {
+  Signal as AngularSignal,
+  WritableSignal as AngularWritableSignal,
+} from '@angular/core';
+import {
+  effect as angularEffect,
+  signal as angularSignal,
+  isSignal as isAngularSignal,
+} from '@angular/core';
+import { effect } from 'alien-signals';
+import type {
+  MaybeUnRef,
+  SupportedFramework,
+  UnComputed,
+  UnSignal,
+} from 'unuse';
+import {
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  unComputed,
+  unSignal,
+} from 'unuse';
+
 declare global {
   // @ts-ignore: set global variable type
   var __UNUSE_FRAMEWORK__: 'angular';
@@ -7,3 +33,157 @@ declare global {
 globalThis.__UNUSE_FRAMEWORK__ = 'angular';
 
 export * from 'unuse';
+
+/**
+ * Tries to convert any given framework-specific ref/signal/state to an `UnSignal`.
+ *
+ * The reactivity will be maintained, meaning that changes to the framework-specific ref/signal/state will also update the `UnSignal`, and vice versa. However, this only works if the given value is reactive.
+ *
+ * @param value The value to convert to an `UnSignal`.
+ *
+ * @returns An `UnSignal` that wraps the given value, or an empty `UnSignal` if the value is `undefined` or `null`.
+ */
+function toUnSignal<T>(value: MaybeUnRef<T>): UnSignal<T> {
+  if (isAngularSignal(value)) {
+    const result = unSignal<T>((value as AngularSignal<T>)());
+
+    angularEffect(() => {
+      result.set((value as AngularSignal<T>)());
+    });
+  }
+
+  return unSignal(value) as UnSignal<T>;
+}
+
+export interface UnResolveOptions<
+  TFramework extends SupportedFramework | undefined = 'angular',
+  TReadonly extends boolean = false,
+> {
+  /**
+   * @default 'angular'
+   */
+  framework?: TFramework;
+  /**
+   * @default false
+   */
+  readonly?: TReadonly;
+}
+
+export type ReadonlyUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'angular',
+> = TFramework extends 'angular' ? AngularSignal<T> : UnComputed<T>;
+
+export type WritableUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'angular',
+> = TFramework extends 'angular' ? AngularWritableSignal<T> : UnSignal<T>;
+
+export type UnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'angular',
+  TReadonly extends boolean = false,
+> = TReadonly extends true
+  ? ReadonlyUnResolveReturn<T, TFramework>
+  : WritableUnResolveReturn<T, TFramework>;
+
+/**
+ * Converts an `UnSignal` to a framework-specific ref/signal/state.
+ *
+ * The reactivity will be maintained, meaning that changes to the `UnSignal` will also update the framework-specific ref/signal/state, and vice versa.
+ *
+ * @param signal The `UnSignal` to convert.
+ * @param options The options to configure the conversion.
+ *
+ * @returns The framework-specific ref/signal/state.
+ */
+function unResolve<
+  T,
+  TFramework extends SupportedFramework | undefined = 'angular',
+  TReadonly extends boolean = false,
+>(
+  signal: UnSignal<T>,
+  options: UnResolveOptions<TFramework, TReadonly> = {}
+): UnResolveReturn<T, TFramework, TReadonly> {
+  const {
+    framework = 'angular' as SupportedFramework | undefined,
+    readonly = false as boolean,
+  } = options;
+
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+  switch (framework) {
+    case 'angular': {
+      // TODO @Shinigami92 2025-06-20: Looks like Angular does not get the same instance and therefore it is not the same signal
+      const state = angularSignal(signal.get());
+
+      effect(() => state.set(signal.get()));
+
+      if (!readonly) {
+        // HACK @Shinigami92 2025-06-20: This is horrible dangerously unsafe, but currently works 👀
+        const originalSet = state.set;
+
+        state.set = (value) => {
+          originalSet(value);
+          signal.set(value);
+        };
+
+        const originalUpdate = state.update;
+
+        state.update = (updater) => {
+          const result = updater(signal.get());
+          originalUpdate(() => result);
+          signal.set(result);
+        };
+      }
+
+      // @ts-expect-error: just do it
+      return state;
+    }
+  }
+
+  if (readonly) {
+    // @ts-expect-error: just do it
+    return unComputed(() => signal.get());
+  }
+
+  // @ts-expect-error: just do it
+  return signal;
+}
+
+/**
+ * Call framework's specific onScopeDispose() if it's inside an effect scope lifecycle, if not, do nothing.
+ *
+ * @param fn
+ */
+function tryOnScopeDispose(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fn: () => void
+): boolean {
+  return false;
+}
+
+/**
+ * UnRef represents any kind of reference or signal that can be dereferenced to get its value.
+ */
+export type UnRef<T> =
+  | AngularSignal<T>
+  | AngularWritableSignal<T>
+  | UnSignal<T>
+  | UnComputed<T>
+  | (() => T);
+
+function isUnRef<T>(value: unknown): value is UnRef<T> {
+  if (isAngularSignal(value)) {
+    return true;
+  }
+
+  return false;
+}
+
+overrideToUnSignalFn(toUnSignal);
+// @ts-expect-error: just do it
+overrideUnResolveFn(unResolve);
+overrideTryOnScopeDisposeFn(tryOnScopeDispose);
+overrideIsUnRefFn(isUnRef);
+
+export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };

--- a/packages/core/src/toUnSignal/index.ts
+++ b/packages/core/src/toUnSignal/index.ts
@@ -6,6 +6,16 @@ import type { MaybeUnRef } from '../unAccess';
 import type { UnSignal } from '../unSignal';
 import { isUnSignal, unSignal } from '../unSignal';
 
+const REGISTRY: {
+  toUnSignalOverride?: typeof toUnSignal;
+} = {
+  toUnSignalOverride: undefined,
+};
+
+export function overrideToUnSignalFn(fn: typeof toUnSignal): void {
+  REGISTRY.toUnSignalOverride = fn;
+}
+
 /**
  * Tries to convert any given framework-specific ref/signal/state to an `UnSignal`.
  *
@@ -26,6 +36,10 @@ export function toUnSignal<T>(value: MaybeUnRef<T>): UnSignal<T> {
 
   if (isUnSignal(value)) {
     return value;
+  }
+
+  if (typeof REGISTRY.toUnSignalOverride === 'function') {
+    return REGISTRY.toUnSignalOverride(value);
   }
 
   const framework = globalThis.__UNUSE_FRAMEWORK__ as

--- a/packages/core/src/tryOnScopeDispose/index.ts
+++ b/packages/core/src/tryOnScopeDispose/index.ts
@@ -1,12 +1,28 @@
 import type { SupportedFramework } from '../_framework';
 import { importedFramework } from '../_framework';
 
+const REGISTRY: {
+  tryOnScopeDisposeOverride?: typeof tryOnScopeDispose;
+} = {
+  tryOnScopeDisposeOverride: undefined,
+};
+
+export function overrideTryOnScopeDisposeFn(
+  fn: typeof tryOnScopeDispose
+): void {
+  REGISTRY.tryOnScopeDisposeOverride = fn;
+}
+
 /**
  * Call framework's specific onScopeDispose() if it's inside an effect scope lifecycle, if not, do nothing.
  *
  * @param fn
  */
 export function tryOnScopeDispose(fn: () => void): boolean {
+  if (typeof REGISTRY.tryOnScopeDisposeOverride === 'function') {
+    return REGISTRY.tryOnScopeDisposeOverride(fn);
+  }
+
   const framework = globalThis.__UNUSE_FRAMEWORK__ as
     | SupportedFramework
     | undefined;

--- a/packages/core/src/unAccess/index.ts
+++ b/packages/core/src/unAccess/index.ts
@@ -35,6 +35,16 @@ export type UnRef<T> =
   | UnComputed<T>
   | (() => T);
 
+const REGISTRY: {
+  isUnRefOverride?: typeof isUnRef;
+} = {
+  isUnRefOverride: undefined,
+};
+
+export function overrideIsUnRefFn(fn: typeof isUnRef): void {
+  REGISTRY.isUnRefOverride = fn;
+}
+
 export function isUnRef<T>(value: unknown): value is UnRef<T> {
   if (value === undefined || value === null) {
     return false;
@@ -52,6 +62,10 @@ export function isUnRef<T>(value: unknown): value is UnRef<T> {
 
   if (isUnSignal(value) || isUnComputed(value)) {
     return true;
+  }
+
+  if (typeof REGISTRY.isUnRefOverride === 'function') {
+    return REGISTRY.isUnRefOverride(value);
   }
 
   const framework = globalThis.__UNUSE_FRAMEWORK__ as

--- a/packages/core/src/unResolve/index.ts
+++ b/packages/core/src/unResolve/index.ts
@@ -71,6 +71,16 @@ export type UnResolveReturn<
   ? ReadonlyUnResolveReturn<T, TFramework>
   : WritableUnResolveReturn<T, TFramework>;
 
+const REGISTRY: {
+  unResolveOverride?: typeof unResolve;
+} = {
+  unResolveOverride: undefined,
+};
+
+export function overrideUnResolveFn(fn: typeof unResolve): void {
+  REGISTRY.unResolveOverride = fn;
+}
+
 /**
  * Converts an `UnSignal` to a framework-specific ref/signal/state.
  *
@@ -91,6 +101,10 @@ export function unResolve<
   signal: UnSignal<T>,
   options: UnResolveOptions<TFramework, TReadonly> = {}
 ): UnResolveReturn<T, TFramework, TReadonly> {
+  if (typeof REGISTRY.unResolveOverride === 'function') {
+    return REGISTRY.unResolveOverride(signal, options);
+  }
+
   const {
     framework = globalThis.__UNUSE_FRAMEWORK__ as
       | SupportedFramework

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,11 @@
     "dist"
   ],
   "dependencies": {
+    "alien-signals": "^2.0.5",
     "unuse": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "19.1.8"
   },
   "peerDependencies": {
     "react": ">=19"

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,27 @@
+/* eslint-disable import-x/export */
+import { effect } from 'alien-signals';
+import type {
+  Dispatch as ReactDispatch,
+  RefObject as ReactRefObject,
+  SetStateAction as SetReactStateAction,
+  useMemo as useReactMemo,
+} from 'react';
+import { useEffect as useReactEffect, useState as useReactState } from 'react';
+import type {
+  MaybeUnRef,
+  SupportedFramework,
+  UnComputed,
+  UnSignal,
+} from 'unuse';
+import {
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  unComputed,
+  unSignal,
+} from 'unuse';
+
 declare global {
   // @ts-ignore: set global variable type
   var __UNUSE_FRAMEWORK__: 'react';
@@ -7,3 +31,168 @@ declare global {
 globalThis.__UNUSE_FRAMEWORK__ = 'react';
 
 export * from 'unuse';
+
+/**
+ * Tries to convert any given framework-specific ref/signal/state to an `UnSignal`.
+ *
+ * The reactivity will be maintained, meaning that changes to the framework-specific ref/signal/state will also update the `UnSignal`, and vice versa. However, this only works if the given value is reactive.
+ *
+ * @param value The value to convert to an `UnSignal`.
+ *
+ * @returns An `UnSignal` that wraps the given value, or an empty `UnSignal` if the value is `undefined` or `null`.
+ */
+function toUnSignal<T>(value: MaybeUnRef<T>): UnSignal<T> {
+  if (value !== null && typeof value === 'object' && 'current' in value) {
+    // got ref
+    const result = unSignal<T>(value.current);
+
+    useReactEffect(() => {
+      result.set(value.current);
+    }, [value]);
+  } else if (Array.isArray(value) && (value as unknown[]).length > 0) {
+    // got state
+    const result = unSignal<T>(value[0] as T);
+
+    useReactEffect(() => {
+      result.set(value[0] as T);
+    });
+  }
+
+  return unSignal(value) as UnSignal<T>;
+}
+
+export interface UnResolveOptions<
+  TFramework extends SupportedFramework | undefined = 'react',
+  TReadonly extends boolean = false,
+> {
+  /**
+   * @default 'react'
+   */
+  framework?: TFramework;
+  /**
+   * @default false
+   */
+  readonly?: TReadonly;
+}
+
+export type ReadonlyUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'react',
+> = TFramework extends 'react'
+  ? ReturnType<typeof useReactMemo<T>>
+  : UnComputed<T>;
+
+export type WritableUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'react',
+> = TFramework extends 'react'
+  ? ReturnType<typeof useReactState<T>>
+  : UnSignal<T>;
+
+export type UnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'react',
+  TReadonly extends boolean = false,
+> = TReadonly extends true
+  ? ReadonlyUnResolveReturn<T, TFramework>
+  : WritableUnResolveReturn<T, TFramework>;
+
+/**
+ * Converts an `UnSignal` to a framework-specific ref/signal/state.
+ *
+ * The reactivity will be maintained, meaning that changes to the `UnSignal` will also update the framework-specific ref/signal/state, and vice versa.
+ *
+ * @param signal The `UnSignal` to convert.
+ * @param options The options to configure the conversion.
+ *
+ * @returns The framework-specific ref/signal/state.
+ */
+function unResolve<
+  T,
+  TFramework extends SupportedFramework | undefined = 'react',
+  TReadonly extends boolean = false,
+>(
+  signal: UnSignal<T>,
+  options: UnResolveOptions<TFramework, TReadonly> = {}
+): UnResolveReturn<T, TFramework, TReadonly> {
+  const {
+    framework = 'react' as SupportedFramework | undefined,
+    readonly = false as boolean,
+  } = options;
+
+  if (framework === 'react') {
+    const state = useReactState(signal.get());
+
+    if (!readonly) {
+      useReactEffect(() => {
+        const value = state[0];
+        signal.set(value);
+      });
+    }
+
+    effect(() => {
+      const newValue = signal.get();
+
+      if (state[0] === newValue) {
+        return;
+      }
+
+      state[1](newValue);
+    });
+
+    // @ts-expect-error: just do it
+    return readonly ? state[0] : (state as ReturnType<typeof useReactState<T>>);
+  }
+
+  if (readonly) {
+    // @ts-expect-error: just do it
+    return unComputed(() => signal.get());
+  }
+
+  // @ts-expect-error: just do it
+  return signal;
+}
+
+/**
+ * Call framework's specific onScopeDispose() if it's inside an effect scope lifecycle, if not, do nothing.
+ *
+ * @param fn
+ */
+function tryOnScopeDispose(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fn: () => void
+): boolean {
+  // React does not have a direct equivalent to onScopeDispose,
+  return false;
+}
+
+/**
+ * UnRef represents any kind of reference or signal that can be dereferenced to get its value.
+ */
+export type UnRef<T> =
+  | ReactRefObject<T> // not sure if ReactRefObject is the correct one we want
+  | [T, ReactDispatch<SetReactStateAction<T>>]
+  | UnSignal<T>
+  | UnComputed<T>
+  | (() => T);
+
+function isUnRef<T>(value: unknown): value is UnRef<T> {
+  if (value !== null && typeof value === 'object' && 'current' in value) {
+    return true;
+  }
+
+  if (Array.isArray(value) && value.length > 0) {
+    return true;
+  }
+
+  return false;
+}
+
+overrideToUnSignalFn(toUnSignal);
+// @ts-expect-error: just do it
+overrideUnResolveFn(unResolve);
+overrideTryOnScopeDisposeFn(tryOnScopeDispose);
+// @ts-expect-error: just do it
+overrideIsUnRefFn(isUnRef);
+
+export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -27,6 +27,7 @@
     "dist"
   ],
   "dependencies": {
+    "alien-signals": "^2.0.5",
     "unuse": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,3 +1,30 @@
+/* eslint-disable import-x/export */
+import { effect } from 'alien-signals';
+import type {
+  Accessor as SolidAccessor,
+  Signal as SolidSignal,
+} from 'solid-js';
+import {
+  createEffect as createSolidEffect,
+  createSignal as createSolidSignal,
+  getOwner as getSolidOwner,
+  onCleanup as onSolidCleanup,
+} from 'solid-js';
+import type {
+  MaybeUnRef,
+  SupportedFramework,
+  UnComputed,
+  UnSignal,
+} from 'unuse';
+import {
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  unComputed,
+  unSignal,
+} from 'unuse';
+
 declare global {
   // @ts-ignore: set global variable type
   var __UNUSE_FRAMEWORK__: 'solid';
@@ -7,3 +34,161 @@ declare global {
 globalThis.__UNUSE_FRAMEWORK__ = 'solid';
 
 export * from 'unuse';
+
+/**
+ * Tries to convert any given framework-specific ref/signal/state to an `UnSignal`.
+ *
+ * The reactivity will be maintained, meaning that changes to the framework-specific ref/signal/state will also update the `UnSignal`, and vice versa. However, this only works if the given value is reactive.
+ *
+ * @param value The value to convert to an `UnSignal`.
+ *
+ * @returns An `UnSignal` that wraps the given value, or an empty `UnSignal` if the value is `undefined` or `null`.
+ */
+function toUnSignal<T>(value: MaybeUnRef<T>): UnSignal<T> {
+  if (typeof value === 'function') {
+    // got Accessor
+    const result = unSignal<T>((value as SolidAccessor<T>)());
+
+    createSolidEffect(() => {
+      result.set((value as SolidAccessor<T>)());
+    });
+  } else if (
+    Array.isArray(value) &&
+    (value as unknown[]).length > 0 &&
+    typeof value[0] === 'function'
+  ) {
+    // got Signal
+    const accessor = value[0] as SolidAccessor<T>;
+    const result = unSignal<T>(accessor());
+
+    createSolidEffect(() => {
+      result.set(accessor());
+    });
+  }
+
+  return unSignal(value) as UnSignal<T>;
+}
+
+export interface UnResolveOptions<
+  TFramework extends SupportedFramework | undefined = 'solid',
+  TReadonly extends boolean = false,
+> {
+  /**
+   * @default 'solid'
+   */
+  framework?: TFramework;
+  /**
+   * @default false
+   */
+  readonly?: TReadonly;
+}
+
+export type ReadonlyUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'solid',
+> = TFramework extends 'solid' ? SolidAccessor<T> : UnComputed<T>;
+
+export type WritableUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'solid',
+> = TFramework extends 'solid' ? SolidSignal<T> : UnSignal<T>;
+
+export type UnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'solid',
+  TReadonly extends boolean = false,
+> = TReadonly extends true
+  ? ReadonlyUnResolveReturn<T, TFramework>
+  : WritableUnResolveReturn<T, TFramework>;
+
+/**
+ * Converts an `UnSignal` to a framework-specific ref/signal/state.
+ *
+ * The reactivity will be maintained, meaning that changes to the `UnSignal` will also update the framework-specific ref/signal/state, and vice versa.
+ *
+ * @param signal The `UnSignal` to convert.
+ * @param options The options to configure the conversion.
+ *
+ * @returns The framework-specific ref/signal/state.
+ */
+function unResolve<
+  T,
+  TFramework extends SupportedFramework | undefined = 'solid',
+  TReadonly extends boolean = false,
+>(
+  signal: UnSignal<T>,
+  options: UnResolveOptions<TFramework, TReadonly> = {}
+): UnResolveReturn<T, TFramework, TReadonly> {
+  const {
+    framework = 'solid' as SupportedFramework | undefined,
+    readonly = false as boolean,
+  } = options;
+
+  if (framework === 'solid') {
+    const state = createSolidSignal(signal.get());
+
+    if (!readonly) {
+      createSolidEffect(() => {
+        const value = state[0]();
+        signal.set(value);
+      });
+    }
+
+    effect(() => state[1](() => signal.get()));
+
+    // @ts-expect-error: just do it
+    return readonly ? state[0] : state;
+  }
+
+  if (readonly) {
+    // @ts-expect-error: just do it
+    return unComputed(() => signal.get());
+  }
+
+  // @ts-expect-error: just do it
+  return signal;
+}
+
+/**
+ * Call framework's specific onScopeDispose() if it's inside an effect scope lifecycle, if not, do nothing.
+ *
+ * @param fn
+ */
+function tryOnScopeDispose(fn: () => void): boolean {
+  if (getSolidOwner()) {
+    onSolidCleanup(fn);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * UnRef represents any kind of reference or signal that can be dereferenced to get its value.
+ */
+export type UnRef<T> =
+  | SolidAccessor<T>
+  | SolidSignal<T>
+  | UnSignal<T>
+  | UnComputed<T>
+  | (() => T);
+
+function isUnRef<T>(value: unknown): value is UnRef<T> {
+  if (typeof value === 'function') {
+    return true;
+  }
+
+  if (Array.isArray(value) && value.length > 0) {
+    return true;
+  }
+
+  return false;
+}
+
+overrideToUnSignalFn(toUnSignal);
+// @ts-expect-error: just do it
+overrideUnResolveFn(unResolve);
+overrideTryOnScopeDisposeFn(tryOnScopeDispose);
+overrideIsUnRefFn(isUnRef);
+
+export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -27,6 +27,7 @@
     "dist"
   ],
   "dependencies": {
+    "alien-signals": "^2.0.5",
     "unuse": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,30 @@
+/* eslint-disable import-x/export */
+import { effect } from 'alien-signals';
+import type {
+  MaybeUnRef,
+  SupportedFramework,
+  UnComputed,
+  UnSignal,
+} from 'unuse';
+import {
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  unComputed,
+  unSignal,
+} from 'unuse';
+import type { ComputedRef as VueComputedRef, Ref as VueRef } from 'vue';
+import {
+  getCurrentScope as getCurrentVueScope,
+  isRef as isVueRef,
+  onScopeDispose as onVueScopeDispose,
+  ref as vueRef,
+  watch as vueWatch,
+} from 'vue';
+
+export * from 'unuse';
+
 declare global {
   // @ts-ignore: set global variable type
   var __UNUSE_FRAMEWORK__: 'vue';
@@ -6,4 +33,142 @@ declare global {
 // @ts-ignore: set global variable
 globalThis.__UNUSE_FRAMEWORK__ = 'vue';
 
-export * from 'unuse';
+/**
+ * Tries to convert any given framework-specific ref/signal/state to an `UnSignal`.
+ *
+ * The reactivity will be maintained, meaning that changes to the framework-specific ref/signal/state will also update the `UnSignal`, and vice versa. However, this only works if the given value is reactive.
+ *
+ * @param value The value to convert to an `UnSignal`.
+ *
+ * @returns An `UnSignal` that wraps the given value, or an empty `UnSignal` if the value is `undefined` or `null`.
+ */
+function toUnSignal<T>(value: MaybeUnRef<T>): UnSignal<T> {
+  if (isVueRef(value)) {
+    const result = unSignal<T>(value.value);
+
+    vueWatch(value, (newValue) => {
+      result.set(newValue);
+    });
+
+    return result;
+  }
+
+  return unSignal(value) as UnSignal<T>;
+}
+
+export interface UnResolveOptions<
+  TFramework extends SupportedFramework | undefined = 'vue',
+  TReadonly extends boolean = false,
+> {
+  /**
+   * @default 'vue'
+   */
+  framework?: TFramework;
+  /**
+   * @default false
+   */
+  readonly?: TReadonly;
+}
+
+export type ReadonlyUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'vue',
+> = TFramework extends 'vue' ? VueComputedRef<T> : UnComputed<T>;
+
+export type WritableUnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'vue',
+> = TFramework extends 'vue' ? VueRef<T> : UnSignal<T>;
+
+export type UnResolveReturn<
+  T,
+  TFramework extends SupportedFramework | undefined = 'vue',
+  TReadonly extends boolean = false,
+> = TReadonly extends true
+  ? ReadonlyUnResolveReturn<T, TFramework>
+  : WritableUnResolveReturn<T, TFramework>;
+
+/**
+ * Converts an `UnSignal` to a framework-specific ref/signal/state.
+ *
+ * The reactivity will be maintained, meaning that changes to the `UnSignal` will also update the framework-specific ref/signal/state, and vice versa.
+ *
+ * @param signal The `UnSignal` to convert.
+ * @param options The options to configure the conversion.
+ *
+ * @returns The framework-specific ref/signal/state.
+ */
+function unResolve<
+  T,
+  TFramework extends SupportedFramework | undefined = 'vue',
+  TReadonly extends boolean = false,
+>(
+  signal: UnSignal<T>,
+  options: UnResolveOptions<TFramework, TReadonly> = {}
+): UnResolveReturn<T, TFramework, TReadonly> {
+  const {
+    framework = 'vue' as SupportedFramework | undefined,
+    readonly = false as boolean,
+  } = options;
+
+  if (framework === 'vue') {
+    const state = vueRef(signal.get());
+
+    effect(() => (state.value = signal.get()));
+
+    if (!readonly) {
+      vueWatch(state, (newValue) => signal.set(newValue), { flush: 'sync' });
+    }
+
+    // @ts-expect-error: just do it
+    return state as VueRef<T>;
+  }
+
+  if (readonly) {
+    // @ts-expect-error: just do it
+    return unComputed(() => signal.get());
+  }
+
+  // @ts-expect-error: just do it
+  return signal;
+}
+
+/**
+ * Call framework's specific onScopeDispose() if it's inside an effect scope lifecycle, if not, do nothing.
+ *
+ * @param fn
+ */
+function tryOnScopeDispose(fn: () => void): boolean {
+  if (getCurrentVueScope()) {
+    onVueScopeDispose(fn);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * UnRef represents any kind of reference or signal that can be dereferenced to get its value.
+ */
+export type UnRef<T> =
+  | VueRef<T>
+  | VueComputedRef<T>
+  | UnSignal<T>
+  | UnComputed<T>
+  | (() => T);
+
+function isUnRef<T>(value: unknown): value is UnRef<T> {
+  if (isVueRef(value)) {
+    return true;
+  }
+
+  return false;
+}
+
+overrideToUnSignalFn(toUnSignal);
+// @ts-expect-error: just do it
+overrideUnResolveFn(unResolve);
+overrideTryOnScopeDisposeFn(tryOnScopeDispose);
+overrideIsUnRefFn(isUnRef);
+
+export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@angular/core':
         specifier: '>=20'
         version: 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2)
+      alien-signals:
+        specifier: 2.0.5
+        version: 2.0.5
       unuse:
         specifier: workspace:*
         version: link:../core
@@ -241,15 +244,25 @@ importers:
 
   packages/react:
     dependencies:
+      alien-signals:
+        specifier: ^2.0.5
+        version: 2.0.5
       react:
         specifier: '>=19'
         version: 19.1.0
       unuse:
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@types/react':
+        specifier: 19.1.8
+        version: 19.1.8
 
   packages/solid:
     dependencies:
+      alien-signals:
+        specifier: ^2.0.5
+        version: 2.0.5
       solid-js:
         specifier: '>=1.9'
         version: 1.9.7
@@ -259,6 +272,9 @@ importers:
 
   packages/vue:
     dependencies:
+      alien-signals:
+        specifier: ^2.0.5
+        version: 2.0.5
       unuse:
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added framework-specific integration layers for Angular, React, Solid, and Vue, enabling seamless interoperability between each framework's reactivity system and the generic reactive utilities.
  - Introduced utilities to convert between framework-specific reactive primitives and the generic reactive abstraction, supporting both readonly and writable modes.
  - Provided lifecycle and cleanup helpers tailored for each supported framework.

- **Chores**
  - Updated dependencies to include support for new reactive utilities across Angular, React, Solid, and Vue packages.
  - Simplified example applications by removing asynchronous initialization steps for all supported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->