### PR TITLE
docs: update readmes

### DIFF
--- a/packages/unuse-angular/README.md
+++ b/packages/unuse-angular/README.md
@@ -1,19 +1,18 @@
-[![NPM package](https://img.shields.io/npm/v/unuse.svg)](https://www.npmjs.com/package/unuse)
-[![Downloads](https://img.shields.io/npm/dt/unuse.svg)](https://www.npmjs.com/package/unuse)
+[![NPM package](https://img.shields.io/npm/v/unuse-angular.svg)](https://www.npmjs.com/package/unuse-angular)
+[![Downloads](https://img.shields.io/npm/dt/unuse-angularvue.svg)](https://www.npmjs.com/package/unuse-angular)
 [![Build Status](https://github.com/un-ts/unuse/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/un-ts/unuse/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/github/license/un-ts/unuse.svg)](https://github.com/un-ts/unuse/blob/main/LICENSE)
 [![Open Collective](https://img.shields.io/opencollective/backers/unts)](https://opencollective.com/unts#section-contributors)
 
-# unuse
+# unuse-angular
 
-`unuse` is a package inspired by `VueUse`, but aims to be framework-agnostic.
+`unuse-angular` is an adapter for the `unuse` package, specifically designed for Angular applications. It provides a set of utilities and composables that can be used in Angular components, inspired by the popular `VueUse` library.
 
-Instead of depending directly on `unuse`, you should install one of the framework-specific adapters:
+# Installation
 
-- [unuse-angular](https://www.npmjs.com/package/unuse-angular)
-- [unuse-react](https://www.npmjs.com/package/unuse-react)
-- [unuse-solid](https://www.npmjs.com/package/unuse-solid)
-- [unuse-vue](https://www.npmjs.com/package/unuse-vue)
+```bash
+npm add unuse-angular
+```
 
 # UNDER CONSTRUCTION
 

--- a/packages/unuse-react/README.md
+++ b/packages/unuse-react/README.md
@@ -1,19 +1,18 @@
-[![NPM package](https://img.shields.io/npm/v/unuse.svg)](https://www.npmjs.com/package/unuse)
-[![Downloads](https://img.shields.io/npm/dt/unuse.svg)](https://www.npmjs.com/package/unuse)
+[![NPM package](https://img.shields.io/npm/v/unuse-react.svg)](https://www.npmjs.com/package/unuse-react)
+[![Downloads](https://img.shields.io/npm/dt/unuse-react.svg)](https://www.npmjs.com/package/unuse-react)
 [![Build Status](https://github.com/un-ts/unuse/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/un-ts/unuse/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/github/license/un-ts/unuse.svg)](https://github.com/un-ts/unuse/blob/main/LICENSE)
 [![Open Collective](https://img.shields.io/opencollective/backers/unts)](https://opencollective.com/unts#section-contributors)
 
-# unuse
+# unuse-react
 
-`unuse` is a package inspired by `VueUse`, but aims to be framework-agnostic.
+`unuse-react` is an adapter for the `unuse` package, specifically designed for React applications. It provides a set of utilities and composables that can be used in React components, inspired by the popular `VueUse` library.
 
-Instead of depending directly on `unuse`, you should install one of the framework-specific adapters:
+# Installation
 
-- [unuse-angular](https://www.npmjs.com/package/unuse-angular)
-- [unuse-react](https://www.npmjs.com/package/unuse-react)
-- [unuse-solid](https://www.npmjs.com/package/unuse-solid)
-- [unuse-vue](https://www.npmjs.com/package/unuse-vue)
+```bash
+npm add unuse-react
+```
 
 # UNDER CONSTRUCTION
 

--- a/packages/unuse-solid/README.md
+++ b/packages/unuse-solid/README.md
@@ -1,19 +1,18 @@
-[![NPM package](https://img.shields.io/npm/v/unuse.svg)](https://www.npmjs.com/package/unuse)
-[![Downloads](https://img.shields.io/npm/dt/unuse.svg)](https://www.npmjs.com/package/unuse)
+[![NPM package](https://img.shields.io/npm/v/unuse-solid.svg)](https://www.npmjs.com/package/unuse-solid)
+[![Downloads](https://img.shields.io/npm/dt/unuse-solid.svg)](https://www.npmjs.com/package/unuse-solid)
 [![Build Status](https://github.com/un-ts/unuse/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/un-ts/unuse/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/github/license/un-ts/unuse.svg)](https://github.com/un-ts/unuse/blob/main/LICENSE)
 [![Open Collective](https://img.shields.io/opencollective/backers/unts)](https://opencollective.com/unts#section-contributors)
 
-# unuse
+# unuse-solid
 
-`unuse` is a package inspired by `VueUse`, but aims to be framework-agnostic.
+`unuse-solid` is an adapter for the `unuse` package, specifically designed for SolidJS applications. It provides a set of utilities and composables that can be used in SolidJS components, inspired by the popular `VueUse` library.
 
-Instead of depending directly on `unuse`, you should install one of the framework-specific adapters:
+# Installation
 
-- [unuse-angular](https://www.npmjs.com/package/unuse-angular)
-- [unuse-react](https://www.npmjs.com/package/unuse-react)
-- [unuse-solid](https://www.npmjs.com/package/unuse-solid)
-- [unuse-vue](https://www.npmjs.com/package/unuse-vue)
+```bash
+npm add unuse-solid
+```
 
 # UNDER CONSTRUCTION
 

--- a/packages/unuse-vue/README.md
+++ b/packages/unuse-vue/README.md
@@ -1,19 +1,18 @@
-[![NPM package](https://img.shields.io/npm/v/unuse.svg)](https://www.npmjs.com/package/unuse)
-[![Downloads](https://img.shields.io/npm/dt/unuse.svg)](https://www.npmjs.com/package/unuse)
+[![NPM package](https://img.shields.io/npm/v/unuse-vue.svg)](https://www.npmjs.com/package/unuse-vue)
+[![Downloads](https://img.shields.io/npm/dt/unuse-vue.svg)](https://www.npmjs.com/package/unuse-vue)
 [![Build Status](https://github.com/un-ts/unuse/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/un-ts/unuse/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/github/license/un-ts/unuse.svg)](https://github.com/un-ts/unuse/blob/main/LICENSE)
 [![Open Collective](https://img.shields.io/opencollective/backers/unts)](https://opencollective.com/unts#section-contributors)
 
-# unuse
+# unuse-vue
 
-`unuse` is a package inspired by `VueUse`, but aims to be framework-agnostic.
+`unuse-vue` is an adapter for the `unuse` package, specifically designed for Vue.js applications. It provides a set of utilities and composables that can be used in Vue components, inspired by the popular `VueUse` library.
 
-Instead of depending directly on `unuse`, you should install one of the framework-specific adapters:
+# Installation
 
-- [unuse-angular](https://www.npmjs.com/package/unuse-angular)
-- [unuse-react](https://www.npmjs.com/package/unuse-react)
-- [unuse-solid](https://www.npmjs.com/package/unuse-solid)
-- [unuse-vue](https://www.npmjs.com/package/unuse-vue)
+```bash
+npm add unuse-vue
+```
 
 # UNDER CONSTRUCTION
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add README files for `unuse-angular`, `unuse-react`, `unuse-solid`, and `unuse-vue` packages, and update `unuse` README to reference these adapters.
> 
>   - **Documentation**:
>     - Add README for `unuse-angular`, `unuse-react`, `unuse-solid`, and `unuse-vue` packages.
>     - Each README includes installation instructions and a description of the package as a framework-specific adapter for `unuse`.
>     - Update `unuse/README.md` to reference the new framework-specific adapters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 3ba8916f4e7ecd1b5fa2d13b755c9c0d451868f8. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new README files for the Angular, React, SolidJS, and Vue.js adapter packages, introducing each package and providing installation instructions.
	- Updated the main package README to recommend using framework-specific adapters instead of the core package directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->