### PR TITLE
test: configure coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      all: true,
+      provider: 'v8',
+      reporter: ['clover', 'cobertura', 'json-summary', 'json', 'lcov', 'text'],
+      exclude: ['examples', '**/*.config.ts'],
+      reportOnFailure: true,
+      thresholds: {
+        // TODO @Shinigami92 2025-06-22: should be:
+        // lines: 90,
+        // statements: 90,
+        // functions: 90,
+        // branches: 85,
+
+        // for now:
+        lines: 40,
+        statements: 40,
+        functions: 70,
+        branches: 70,
+      },
+    },
+    reporters: process.env.CI
+      ? ['default', 'github-actions']
+      : [['default', { summary: false }]],
+  },
+});


### PR DESCRIPTION
This will fix https://github.com/un-ts/unuse/actions/workflows/coverage-report.yml
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `vitest.config.ts` to configure test coverage with specific providers, reporters, and thresholds for CI and local environments.
> 
>   - **Configuration**:
>     - Adds `vitest.config.ts` to configure test coverage.
>     - Sets coverage provider to `v8` and includes multiple reporters: `clover`, `cobertura`, `json-summary`, `json`, `lcov`, `text`.
>     - Excludes `examples` and `**/*.config.ts` from coverage.
>     - Sets coverage thresholds: `lines: 40`, `statements: 40`, `functions: 70`, `branches: 70`.
>     - Configures reporters based on `CI` environment variable: `default` and `github-actions` for CI, `default` with no summary otherwise.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 49defb76b331603dd51d61c435716ba4cc2f6b57. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new test configuration to enable detailed coverage reporting and set initial coverage thresholds.
  - Coverage reports are now generated in multiple formats and will be produced even if tests fail.
  - Test reporting adapts automatically when running in continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->