### PR TITLE
chore: prepare for unuse.js.org

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,8 +4,6 @@ export default defineConfig({
   title: 'unuse',
   description: 'Documentation Website for unuse',
 
-  base: process.env.NODE_ENV === 'production' ? '/unuse/' : '/',
-
   themeConfig: {
     nav: [{ text: 'Home', link: '/' }],
 


### PR DESCRIPTION
https://github.com/js-org/js.org/pull/9897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated site configuration to use the default base path for documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove conditional base path setting in VitePress `config.ts` for production environment.
> 
>   - **Configuration**:
>     - Removed conditional `base` path setting in `config.ts` for VitePress, which previously set `/unuse/` for production and `/` otherwise.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 9e243331a4b50a10ac7baf44e3ba14c2fe83cb57. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->