### PR TITLE
test: cover framework adapters

### DIFF
--- a/.changeset/bitter-cameras-give.md
+++ b/.changeset/bitter-cameras-give.md
@@ -1,0 +1,9 @@
+---
+'unuse-angular': patch
+'unuse-react': patch
+'unuse-solid': patch
+'unuse-vue': patch
+'unuse': patch
+---
+
+fix: isUnRef recognize also unSignal, unComputed and getter functions

--- a/.changeset/dirty-buttons-open.md
+++ b/.changeset/dirty-buttons-open.md
@@ -1,0 +1,9 @@
+---
+'unuse-angular': patch
+'unuse-react': patch
+'unuse-solid': patch
+'unuse-vue': patch
+'unuse': patch
+---
+
+fix!: remove internal override functions from public API

--- a/packages/unuse-angular/package.json
+++ b/packages/unuse-angular/package.json
@@ -30,6 +30,9 @@
     "alien-signals": "2.0.5",
     "unuse": "workspace:*"
   },
+  "devDependencies": {
+    "@angular/platform-browser": "20.0.4"
+  },
   "peerDependencies": {
     "@angular/core": ">=20"
   },

--- a/packages/unuse-angular/src/index.spec.ts
+++ b/packages/unuse-angular/src/index.spec.ts
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+
+import {
+  computed,
+  NgModule,
+  provideZonelessChangeDetection,
+  signal,
+} from '@angular/core';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  isUnComputed,
+  isUnRef,
+  isUnSignal,
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unComputed,
+  unResolve,
+  unSignal,
+} from '.';
+
+@NgModule({ providers: [provideZonelessChangeDetection()] })
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+class ZonelessTestModule {}
+
+describe('unuse-angular', () => {
+  it('should export correct global variable', () => {
+    expect(globalThis.__UNUSE_FRAMEWORK__).toBe('angular');
+  });
+
+  beforeAll(() => {
+    getTestBed().initTestEnvironment(
+      [BrowserTestingModule, ZonelessTestModule],
+      platformBrowserTesting()
+    );
+  });
+
+  describe('toUnSignal', () => {
+    it('should export toUnSignal function', () => {
+      expect(toUnSignal).toBeTypeOf('function');
+    });
+
+    it('should convert an Angular Signal to an UnSignal', () => {
+      const angularSignal = signal(42);
+      getTestBed().runInInjectionContext(() => {
+        const mySignal = toUnSignal(angularSignal);
+        expect(mySignal.get()).toBe(42);
+
+        mySignal.set(100);
+      });
+
+      expect(angularSignal()).toBe(100);
+    });
+
+    it('should convert a non-reactive value to an UnSignal', () => {
+      const mySignal = toUnSignal(42);
+      expect(mySignal.get()).toBe(42);
+
+      mySignal.set(100);
+      expect(mySignal.get()).toBe(100);
+    });
+  });
+
+  describe('unResolve', () => {
+    it('should export unResolve function', () => {
+      expect(unResolve).toBeTypeOf('function');
+    });
+
+    it('should resolve an UnSignal to an Angular WritableSignal', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal);
+
+      expect(resolved()).toBe(42);
+      resolved.set(100);
+      expect(mySignal.get()).toBe(100);
+    });
+
+    it('should resolve an UnSignal to an Angular Signal when readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { readonly: true });
+
+      expect(resolved()).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { framework: 'none' });
+
+      expect(resolved).toSatisfy(isUnSignal);
+      expect(resolved.get()).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, {
+        framework: 'none',
+        readonly: true,
+      });
+
+      expect(resolved).toSatisfy(isUnComputed);
+      expect(resolved.get()).toBe(42);
+    });
+  });
+
+  describe('tryOnScopeDispose', () => {
+    it('should export tryOnScopeDispose function', () => {
+      expect(tryOnScopeDispose).toBeTypeOf('function');
+    });
+
+    it.todo('should call the provided callback on scope dispose', () => {
+      const callback = vi.fn();
+      let isDisposable!: boolean;
+
+      getTestBed().runInInjectionContext(() => {
+        isDisposable = tryOnScopeDispose(callback);
+
+        expect(isDisposable).toBe(true);
+        expect(callback).toHaveBeenCalledTimes(0);
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return false if not inside an Angular effect scope', () => {
+      const callback = vi.fn();
+      const isDisposable = tryOnScopeDispose(callback);
+
+      expect(isDisposable).toBe(false);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('isUnRef', () => {
+    it('should export isUnRef function', () => {
+      expect(isUnRef).toBeTypeOf('function');
+    });
+
+    it('should return true for Angular signal', () => {
+      const angularSignal = signal(42);
+      expect(isUnRef(angularSignal)).toBe(true);
+    });
+
+    it('should return true for Angular computed', () => {
+      const angularComputed = computed(() => 42);
+      expect(isUnRef(angularComputed)).toBe(true);
+    });
+
+    it('should return true for UnSignal', () => {
+      const mySignal = unSignal(42);
+      expect(isUnRef(mySignal)).toBe(true);
+    });
+
+    it('should return true for UnComputed', () => {
+      const myComputed = unComputed(() => 42);
+      expect(isUnRef(myComputed)).toBe(true);
+    });
+
+    it('should return true for Getters', () => {
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const myGetter = () => 42;
+      expect(isUnRef(myGetter)).toBe(true);
+    });
+
+    it('should return false for non-UnRef values', () => {
+      expect(isUnRef(42)).toBe(false);
+      expect(isUnRef('string')).toBe(false);
+      expect(isUnRef({})).toBe(false);
+      expect(isUnRef([])).toBe(false);
+    });
+  });
+
+  it('should not expose override functions', () => {
+    expect(overrideToUnSignalFn).toBeUndefined();
+    expect(overrideUnResolveFn).toBeUndefined();
+    expect(overrideTryOnScopeDisposeFn).toBeUndefined();
+    expect(overrideIsUnRefFn).toBeUndefined();
+  });
+});

--- a/packages/unuse-angular/src/index.ts
+++ b/packages/unuse-angular/src/index.ts
@@ -16,6 +16,8 @@ import type {
   UnSignal,
 } from 'unuse';
 import {
+  isUnComputed,
+  isUnSignal,
   overrideIsUnRefFn,
   overrideToUnSignalFn,
   overrideTryOnScopeDisposeFn,
@@ -181,11 +183,13 @@ export type UnRef<T> =
   | (() => T);
 
 function isUnRef<T>(value: unknown): value is UnRef<T> {
-  if (isAngularSignal(value)) {
-    return true;
-  }
-
-  return false;
+  return (
+    isAngularSignal(value) ||
+    // getter
+    typeof value === 'function' ||
+    isUnSignal(value) ||
+    isUnComputed(value)
+  );
 }
 
 overrideToUnSignalFn(toUnSignal);
@@ -194,4 +198,17 @@ overrideUnResolveFn(unResolve);
 overrideTryOnScopeDisposeFn(tryOnScopeDispose);
 overrideIsUnRefFn(isUnRef);
 
-export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };
+// Above we export everything from 'unuse'.
+// So here we export some internal functions as undefined to make it inaccessible from the public API.
+const UNDEFINED = undefined;
+
+export {
+  isUnRef,
+  UNDEFINED as overrideIsUnRefFn,
+  UNDEFINED as overrideToUnSignalFn,
+  UNDEFINED as overrideTryOnScopeDisposeFn,
+  UNDEFINED as overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unResolve,
+};

--- a/packages/unuse-react/package.json
+++ b/packages/unuse-react/package.json
@@ -31,6 +31,7 @@
     "unuse": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/react": "16.3.0",
     "@types/react": "19.1.8"
   },
   "peerDependencies": {

--- a/packages/unuse-react/src/index.spec.ts
+++ b/packages/unuse-react/src/index.spec.ts
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react';
+import { useMemo, useRef, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isUnComputed,
+  isUnRef,
+  isUnSignal,
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unComputed,
+  unResolve,
+  unSignal,
+} from '.';
+
+describe('unuse-react', () => {
+  it('should export correct global variable', () => {
+    expect(globalThis.__UNUSE_FRAMEWORK__).toBe('react');
+  });
+
+  describe('toUnSignal', () => {
+    it('should export toUnSignal function', () => {
+      expect(toUnSignal).toBeTypeOf('function');
+    });
+
+    it.todo('should convert a React State to an UnSignal', () => {
+      const hook = renderHook(() => {
+        const reactState = useState(42);
+        const mySignal = toUnSignal(reactState);
+        expect(mySignal.get()).toBe(42);
+
+        mySignal.set(100);
+      });
+
+      expect(hook.result.current).toBe(100);
+    });
+
+    it.todo('should convert a React Ref to an UnSignal', () => {
+      const hook = renderHook(() => {
+        const reactRef = useRef(42);
+        const mySignal = toUnSignal(reactRef);
+        expect(mySignal.get()).toBe(42);
+
+        mySignal.set(100);
+        return reactRef;
+      });
+
+      expect(hook.result.current.current).toBe(100);
+    });
+
+    it('should convert a non-reactive value to an UnSignal', () => {
+      const mySignal = toUnSignal(42);
+      expect(mySignal.get()).toBe(42);
+
+      mySignal.set(100);
+      expect(mySignal.get()).toBe(100);
+    });
+  });
+
+  describe('unResolve', () => {
+    it('should export unResolve function', () => {
+      expect(unResolve).toBeTypeOf('function');
+    });
+
+    it.todo('should resolve an UnSignal to a React State', () => {
+      const mySignal = unSignal(42);
+      const hook = renderHook(() => {
+        const reactState = unResolve(mySignal);
+        expect(reactState[0]).toBe(42);
+        return reactState;
+      });
+
+      hook.result.current[1](100);
+
+      expect(mySignal.get()).toBe(100);
+    });
+
+    it('should resolve an UnSignal to a React value when readonly is true', () => {
+      const mySignal = unSignal(42);
+      const hook = renderHook(() => unResolve(mySignal, { readonly: true }));
+
+      expect(hook.result.current).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { framework: 'none' });
+
+      expect(resolved).toSatisfy(isUnSignal);
+      expect(resolved.get()).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, {
+        framework: 'none',
+        readonly: true,
+      });
+
+      expect(resolved).toSatisfy(isUnComputed);
+      expect(resolved.get()).toBe(42);
+    });
+  });
+
+  describe('tryOnScopeDispose', () => {
+    it('should export tryOnScopeDispose function', () => {
+      expect(tryOnScopeDispose).toBeTypeOf('function');
+    });
+
+    it.todo('should call the provided callback on scope dispose', () => {
+      const callback = vi.fn();
+      let isDisposable!: boolean;
+
+      const hook = renderHook(() => {
+        isDisposable = tryOnScopeDispose(callback);
+      });
+
+      expect(isDisposable).toBe(true);
+      expect(callback).toHaveBeenCalledTimes(0);
+
+      hook.unmount();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return false if not inside a React effect scope', () => {
+      const callback = vi.fn();
+      const isDisposable = tryOnScopeDispose(callback);
+
+      expect(isDisposable).toBe(false);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('isUnRef', () => {
+    it('should export isUnRef function', () => {
+      expect(isUnRef).toBeTypeOf('function');
+    });
+
+    it('should return true for React State', () => {
+      const hook = renderHook(() => useState(42));
+      expect(isUnRef(hook.result.current)).toBe(true);
+    });
+
+    it('should return true for React Ref', () => {
+      const hook = renderHook(() => useRef(42));
+      expect(isUnRef(hook.result.current)).toBe(true);
+    });
+
+    it('should return true for React Memo', () => {
+      // TODO @Shinigami92 2025-06-24: This is tricky 🤔
+      // useMemo returns a primitive value, so we cant check it in isUnRef
+      const hook = renderHook(() => useMemo(() => 42, []));
+      expect(isUnRef(hook.result.current)).toBe(false);
+    });
+
+    it('should return true for UnSignal', () => {
+      const mySignal = unSignal(42);
+      expect(isUnRef(mySignal)).toBe(true);
+    });
+
+    it('should return true for UnComputed', () => {
+      const myComputed = unComputed(() => 42);
+      expect(isUnRef(myComputed)).toBe(true);
+    });
+
+    it('should return true for Getters', () => {
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const myGetter = () => 42;
+      expect(isUnRef(myGetter)).toBe(true);
+    });
+
+    it('should return false for non-UnRef values', () => {
+      expect(isUnRef(42)).toBe(false);
+      expect(isUnRef('string')).toBe(false);
+      expect(isUnRef({})).toBe(false);
+      expect(isUnRef([])).toBe(false);
+    });
+  });
+
+  it('should not expose override functions', () => {
+    expect(overrideToUnSignalFn).toBeUndefined();
+    expect(overrideUnResolveFn).toBeUndefined();
+    expect(overrideTryOnScopeDisposeFn).toBeUndefined();
+    expect(overrideIsUnRefFn).toBeUndefined();
+  });
+});

--- a/packages/unuse-solid/package.json
+++ b/packages/unuse-solid/package.json
@@ -30,6 +30,9 @@
     "alien-signals": "^2.0.5",
     "unuse": "workspace:*"
   },
+  "devDependencies": {
+    "@solidjs/testing-library": "0.8.10"
+  },
   "peerDependencies": {
     "solid-js": ">=1.9"
   },

--- a/packages/unuse-solid/src/index.spec.ts
+++ b/packages/unuse-solid/src/index.spec.ts
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@solidjs/testing-library';
+import { createMemo, createSignal } from 'solid-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isUnComputed,
+  isUnRef,
+  isUnSignal,
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unComputed,
+  unResolve,
+  unSignal,
+} from '.';
+
+describe('unuse-solid', () => {
+  it('should export correct global variable', () => {
+    expect(globalThis.__UNUSE_FRAMEWORK__).toBe('solid');
+  });
+
+  describe('toUnSignal', () => {
+    it('should export toUnSignal function', () => {
+      expect(toUnSignal).toBeTypeOf('function');
+    });
+
+    it('should convert a Solid Signal to an UnSignal', () => {
+      const solidSignal = createSignal(42);
+      const mySignal = toUnSignal(solidSignal);
+      expect(mySignal.get()).toBe(42);
+
+      mySignal.set(100);
+      expect(solidSignal[0]()).toBe(100);
+    });
+
+    it('should convert a non-reactive value to an UnSignal', () => {
+      const mySignal = toUnSignal(42);
+      expect(mySignal.get()).toBe(42);
+
+      mySignal.set(100);
+      expect(mySignal.get()).toBe(100);
+    });
+  });
+
+  describe('unResolve', () => {
+    it('should export unResolve function', () => {
+      expect(unResolve).toBeTypeOf('function');
+    });
+
+    it.todo('should resolve an UnSignal to a Solid Signal', () => {
+      const mySignal = unSignal(42);
+
+      renderHook(() => {
+        const resolved = unResolve(mySignal);
+        expect(resolved[0]()).toBe(42);
+
+        resolved[1](100);
+
+        return resolved;
+      });
+      expect(mySignal.get()).toBe(100);
+    });
+
+    it('should resolve an UnSignal to a Signal Accessor when readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { readonly: true });
+
+      expect(resolved()).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { framework: 'none' });
+
+      expect(resolved).toSatisfy(isUnSignal);
+      expect(resolved.get()).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, {
+        framework: 'none',
+        readonly: true,
+      });
+
+      expect(resolved).toSatisfy(isUnComputed);
+      expect(resolved.get()).toBe(42);
+    });
+  });
+
+  describe('tryOnScopeDispose', () => {
+    it('should export tryOnScopeDispose function', () => {
+      expect(tryOnScopeDispose).toBeTypeOf('function');
+    });
+
+    it('should call the provided callback on scope dispose', () => {
+      const callback = vi.fn();
+
+      const hook = renderHook(() => tryOnScopeDispose(callback));
+      const isDisposable = hook.result;
+      expect(isDisposable).toBe(true);
+      expect(callback).toHaveBeenCalledTimes(0);
+
+      hook.cleanup();
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return false if not inside a Solid effect scope', () => {
+      const callback = vi.fn();
+      const isDisposable = tryOnScopeDispose(callback);
+
+      expect(isDisposable).toBe(false);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('isUnRef', () => {
+    it('should export isUnRef function', () => {
+      expect(isUnRef).toBeTypeOf('function');
+    });
+
+    it('should return true for Solid Signal', () => {
+      const solidSignal = createSignal(42);
+      expect(isUnRef(solidSignal)).toBe(true);
+    });
+
+    it('should return true for Solid Memo', () => {
+      const solidMemo = createMemo(() => 42);
+      expect(isUnRef(solidMemo)).toBe(true);
+    });
+
+    it('should return true for UnSignal', () => {
+      const mySignal = unSignal(42);
+      expect(isUnRef(mySignal)).toBe(true);
+    });
+
+    it('should return true for UnComputed', () => {
+      const myComputed = unComputed(() => 42);
+      expect(isUnRef(myComputed)).toBe(true);
+    });
+
+    it('should return true for Getters', () => {
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const myGetter = () => 42;
+      expect(isUnRef(myGetter)).toBe(true);
+    });
+
+    it('should return false for non-UnRef values', () => {
+      expect(isUnRef(42)).toBe(false);
+      expect(isUnRef('string')).toBe(false);
+      expect(isUnRef({})).toBe(false);
+      expect(isUnRef([])).toBe(false);
+    });
+  });
+
+  it('should not expose override functions', () => {
+    expect(overrideToUnSignalFn).toBeUndefined();
+    expect(overrideUnResolveFn).toBeUndefined();
+    expect(overrideTryOnScopeDisposeFn).toBeUndefined();
+    expect(overrideIsUnRefFn).toBeUndefined();
+  });
+});

--- a/packages/unuse-solid/src/index.ts
+++ b/packages/unuse-solid/src/index.ts
@@ -17,6 +17,8 @@ import type {
   UnSignal,
 } from 'unuse';
 import {
+  isUnComputed,
+  isUnSignal,
   overrideIsUnRefFn,
   overrideToUnSignalFn,
   overrideTryOnScopeDisposeFn,
@@ -182,15 +184,14 @@ export type UnRef<T> =
   | (() => T);
 
 function isUnRef<T>(value: unknown): value is UnRef<T> {
-  if (typeof value === 'function') {
-    return true;
-  }
-
-  if (Array.isArray(value) && value.length > 0) {
-    return true;
-  }
-
-  return false;
+  return (
+    // signal
+    (Array.isArray(value) && value.length > 0) ||
+    // accessor(/getter)
+    typeof value === 'function' ||
+    isUnSignal(value) ||
+    isUnComputed(value)
+  );
 }
 
 overrideToUnSignalFn(toUnSignal);
@@ -199,4 +200,17 @@ overrideUnResolveFn(unResolve);
 overrideTryOnScopeDisposeFn(tryOnScopeDispose);
 overrideIsUnRefFn(isUnRef);
 
-export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };
+// Above we export everything from 'unuse'.
+// So here we export some internal functions as undefined to make it inaccessible from the public API.
+const UNDEFINED = undefined;
+
+export {
+  isUnRef,
+  UNDEFINED as overrideIsUnRefFn,
+  UNDEFINED as overrideToUnSignalFn,
+  UNDEFINED as overrideTryOnScopeDisposeFn,
+  UNDEFINED as overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unResolve,
+};

--- a/packages/unuse-vue/src/index.spec.ts
+++ b/packages/unuse-vue/src/index.spec.ts
@@ -1,0 +1,191 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/naming-convention */
+
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import { computed, createApp, defineComponent, h, ref } from 'vue';
+import {
+  isUnComputed,
+  isUnRef,
+  isUnSignal,
+  overrideIsUnRefFn,
+  overrideToUnSignalFn,
+  overrideTryOnScopeDisposeFn,
+  overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unComputed,
+  unResolve,
+  unSignal,
+} from '.';
+
+type InstanceType<V> = V extends { new (...arg: any[]): infer X } ? X : never;
+type VM<V> = InstanceType<V> & { unmount: () => void };
+
+function mount<V>(Comp: V) {
+  const el = document.createElement('div');
+  const app = createApp(Comp as any);
+
+  const unmount = () => app.unmount();
+  const comp = app.mount(el) as any as VM<V>;
+  comp.unmount = unmount;
+  return comp;
+}
+
+function useSetup<V>(setup: () => V) {
+  const Comp = defineComponent({
+    setup,
+    render() {
+      return h('div', []);
+    },
+  });
+
+  return mount(Comp);
+}
+
+describe('unuse-vue', () => {
+  it('should export correct global variable', () => {
+    expect(globalThis.__UNUSE_FRAMEWORK__).toBe('vue');
+  });
+
+  describe('toUnSignal', () => {
+    it('should export toUnSignal function', () => {
+      expect(toUnSignal).toBeTypeOf('function');
+    });
+
+    it('should convert a Vue ref to an UnSignal', () => {
+      const vueRef = ref(42);
+      const mySignal = toUnSignal(vueRef);
+      expect(mySignal.get()).toBe(42);
+
+      mySignal.set(100);
+      expect(vueRef.value).toBe(100);
+    });
+
+    it('should convert a non-reactive value to an UnSignal', () => {
+      const mySignal = toUnSignal(42);
+      expect(mySignal.get()).toBe(42);
+
+      mySignal.set(100);
+      expect(mySignal.get()).toBe(100);
+    });
+  });
+
+  describe('unResolve', () => {
+    it('should export unResolve function', () => {
+      expect(unResolve).toBeTypeOf('function');
+    });
+
+    it('should resolve an UnSignal to a Vue ref', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal);
+
+      expect(resolved.value).toBe(42);
+      resolved.value = 100;
+      expect(mySignal.get()).toBe(100);
+    });
+
+    it('should resolve an UnSignal to a Vue computed ref when readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { readonly: true });
+
+      expect(resolved.value).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, { framework: 'none' });
+
+      expect(resolved).toSatisfy(isUnSignal);
+      expect(resolved.get()).toBe(42);
+    });
+
+    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+      const mySignal = unSignal(42);
+      const resolved = unResolve(mySignal, {
+        framework: 'none',
+        readonly: true,
+      });
+
+      expect(resolved).toSatisfy(isUnComputed);
+      expect(resolved.get()).toBe(42);
+    });
+  });
+
+  describe('tryOnScopeDispose', () => {
+    it('should export tryOnScopeDispose function', () => {
+      expect(tryOnScopeDispose).toBeTypeOf('function');
+    });
+
+    it('should call the provided callback on scope dispose', () => {
+      const callback = vi.fn();
+      let isDisposable!: boolean;
+
+      const { unmount } = useSetup(() => {
+        isDisposable = tryOnScopeDispose(callback);
+      });
+
+      expect(isDisposable).toBe(true);
+      expect(callback).toHaveBeenCalledTimes(0);
+
+      unmount();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return false if not inside a Vue effect scope', () => {
+      const callback = vi.fn();
+      const isDisposable = tryOnScopeDispose(callback);
+
+      expect(isDisposable).toBe(false);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('isUnRef', () => {
+    it('should export isUnRef function', () => {
+      expect(isUnRef).toBeTypeOf('function');
+    });
+
+    it('should return true for Vue ref', () => {
+      const vueRef = ref(42);
+      expect(isUnRef(vueRef)).toBe(true);
+    });
+
+    it('should return true for Vue computed ref', () => {
+      const vueComputed = computed(() => 42);
+      expect(isUnRef(vueComputed)).toBe(true);
+    });
+
+    it('should return true for UnSignal', () => {
+      const mySignal = unSignal(42);
+      expect(isUnRef(mySignal)).toBe(true);
+    });
+
+    it('should return true for UnComputed', () => {
+      const myComputed = unComputed(() => 42);
+      expect(isUnRef(myComputed)).toBe(true);
+    });
+
+    it('should return true for Getters', () => {
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const myGetter = () => 42;
+      expect(isUnRef(myGetter)).toBe(true);
+    });
+
+    it('should return false for non-UnRef values', () => {
+      expect(isUnRef(42)).toBe(false);
+      expect(isUnRef('string')).toBe(false);
+      expect(isUnRef({})).toBe(false);
+      expect(isUnRef([])).toBe(false);
+    });
+  });
+
+  it('should not expose override functions', () => {
+    expect(overrideToUnSignalFn).toBeUndefined();
+    expect(overrideUnResolveFn).toBeUndefined();
+    expect(overrideTryOnScopeDisposeFn).toBeUndefined();
+    expect(overrideIsUnRefFn).toBeUndefined();
+  });
+});

--- a/packages/unuse-vue/src/index.ts
+++ b/packages/unuse-vue/src/index.ts
@@ -7,6 +7,8 @@ import type {
   UnSignal,
 } from 'unuse';
 import {
+  isUnComputed,
+  isUnSignal,
   overrideIsUnRefFn,
   overrideToUnSignalFn,
   overrideTryOnScopeDisposeFn,
@@ -169,11 +171,13 @@ export type UnRef<T> =
   | (() => T);
 
 function isUnRef<T>(value: unknown): value is UnRef<T> {
-  if (isVueRef(value)) {
-    return true;
-  }
-
-  return false;
+  return (
+    isVueRef(value) ||
+    // getter
+    typeof value === 'function' ||
+    isUnSignal(value) ||
+    isUnComputed(value)
+  );
 }
 
 overrideToUnSignalFn(toUnSignal);
@@ -182,4 +186,17 @@ overrideUnResolveFn(unResolve);
 overrideTryOnScopeDisposeFn(tryOnScopeDispose);
 overrideIsUnRefFn(isUnRef);
 
-export { isUnRef, toUnSignal, tryOnScopeDispose, unResolve };
+// Above we export everything from 'unuse'.
+// So here we export some internal functions as undefined to make it inaccessible from the public API.
+const UNDEFINED = undefined;
+
+export {
+  isUnRef,
+  UNDEFINED as overrideIsUnRefFn,
+  UNDEFINED as overrideToUnSignalFn,
+  UNDEFINED as overrideTryOnScopeDisposeFn,
+  UNDEFINED as overrideUnResolveFn,
+  toUnSignal,
+  tryOnScopeDispose,
+  unResolve,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,10 @@ importers:
       unuse:
         specifier: workspace:*
         version: link:../unuse
+    devDependencies:
+      '@angular/platform-browser':
+        specifier: 20.0.4
+        version: 20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))
 
   packages/unuse-react:
     dependencies:
@@ -269,6 +273,9 @@ importers:
         specifier: workspace:*
         version: link:../unuse
     devDependencies:
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/react':
         specifier: 19.1.8
         version: 19.1.8
@@ -284,6 +291,10 @@ importers:
       unuse:
         specifier: workspace:*
         version: link:../unuse
+    devDependencies:
+      '@solidjs/testing-library':
+        specifier: 0.8.10
+        version: 0.8.10(solid-js@1.9.7)
 
   packages/unuse-vue:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
       all: true,
       provider: 'v8',
       reporter: ['clover', 'cobertura', 'json-summary', 'json', 'lcov', 'text'],
-      exclude: ['examples', '**/*.config.ts'],
+      exclude: [
+        '**/dist/**',
+        '**/*.config.ts',
+        'docs/.vitepress/**',
+        'examples',
+      ],
       reportOnFailure: true,
       thresholds: {
         // TODO @Shinigami92 2025-06-22: should be:
@@ -17,10 +22,10 @@ export default defineConfig({
         // branches: 85,
 
         // for now:
-        lines: 40,
-        statements: 40,
-        functions: 70,
-        branches: 70,
+        lines: 75,
+        statements: 75,
+        functions: 75,
+        branches: 80,
       },
     },
     reporters: process.env.CI


### PR DESCRIPTION
well... I'm glad I start covering these 😅 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add test coverage for framework adapters, improve `isUnRef` detection, and remove internal functions from public API.
> 
>   - **Tests**:
>     - Added test suites for Angular, React, Solid, and Vue in `index.spec.ts` files to verify reactive utility functions and framework integration.
>   - **Bug Fixes**:
>     - `isUnRef` now recognizes `unSignal`, `unComputed`, and getter functions in `index.ts` for Angular, React, Solid, and Vue.
>   - **Refactor**:
>     - Removed internal override functions from public API in `index.ts` for Angular, React, Solid, and Vue.
>   - **Chores**:
>     - Updated development dependencies in `package.json` for Angular, React, and Solid.
>     - Enhanced test coverage thresholds and refined coverage exclusions in `vitest.config.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for d10fc9919a99a4c0c35a2d113bee3ba89b65302e. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive test suites for Angular, React, Solid, and Vue packages to verify reactive utility functions and framework integration.

- **Bug Fixes**
  - Improved detection of reactive references across Angular, React, Solid, and Vue, ensuring broader compatibility with signals, computed values, and getter functions.

- **Chores**
  - Updated development dependencies for Angular, React, and Solid packages.
  - Enhanced test coverage thresholds and refined coverage exclusions in test configuration.

- **Refactor**
  - Internal override functions are no longer exposed in public APIs, increasing encapsulation and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->