### PR TITLE
feat: framework fallback none

### DIFF
--- a/.changeset/thick-candles-doubt.md
+++ b/.changeset/thick-candles-doubt.md
@@ -1,0 +1,9 @@
+---
+'unuse': minor
+'unuse-angular': minor
+'unuse-react': minor
+'unuse-solid': minor
+'unuse-vue': minor
+---
+
+feat: framework fallback `'none'`

--- a/packages/unuse/src/_framework/index.ts
+++ b/packages/unuse/src/_framework/index.ts
@@ -1,4 +1,4 @@
-export type SupportedFramework = 'angular' | 'react' | 'solid' | 'vue';
+export type SupportedFramework = 'angular' | 'react' | 'solid' | 'vue' | 'none';
 
 let Angular: typeof import('@angular/core') | undefined;
 let React: typeof import('react') | undefined;
@@ -8,7 +8,7 @@ let Vue: typeof import('vue') | undefined;
 // HACK @Shinigami92 2025-06-16: https://github.com/tc39/proposal-import-sync
 
 export async function initFrameworkImport(
-  framework: SupportedFramework
+  framework: Exclude<SupportedFramework, 'none'>
 ): Promise<void> {
   switch (framework) {
     case 'angular': {
@@ -48,18 +48,19 @@ export async function initFrameworkImport(
   throw new Error(`Unsupported framework: ${framework}`);
 }
 
-export type ImportedFrameworkReturn<TFramework extends SupportedFramework> =
-  TFramework extends 'angular'
-    ? typeof import('@angular/core')
-    : TFramework extends 'react'
-      ? typeof import('react')
-      : TFramework extends 'solid'
-        ? typeof import('solid-js')
-        : typeof import('vue');
+export type ImportedFrameworkReturn<
+  TFramework extends Exclude<SupportedFramework, 'none'>,
+> = TFramework extends 'angular'
+  ? typeof import('@angular/core')
+  : TFramework extends 'react'
+    ? typeof import('react')
+    : TFramework extends 'solid'
+      ? typeof import('solid-js')
+      : typeof import('vue');
 
-export function importedFramework<TFramework extends SupportedFramework>(
-  framework: TFramework
-): ImportedFrameworkReturn<TFramework> {
+export function importedFramework<
+  TFramework extends Exclude<SupportedFramework, 'none'>,
+>(framework: TFramework): ImportedFrameworkReturn<TFramework> {
   switch (framework) {
     case 'angular': {
       if (!Angular) {

--- a/packages/unuse/src/toUnSignal/index.ts
+++ b/packages/unuse/src/toUnSignal/index.ts
@@ -44,11 +44,10 @@ export function toUnSignal<T>(value: MaybeUnRef<T>): UnSignal<T> {
     return REGISTRY.toUnSignalOverride(value);
   }
 
-  const framework = globalThis.__UNUSE_FRAMEWORK__ as
-    | SupportedFramework
-    | undefined;
-
-  if (!framework) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const framework = (globalThis.__UNUSE_FRAMEWORK__ ||
+    'none') as SupportedFramework;
+  if (framework === 'none') {
     return unSignal(value) as UnSignal<T>;
   }
 

--- a/packages/unuse/src/tryOnScopeDispose/index.ts
+++ b/packages/unuse/src/tryOnScopeDispose/index.ts
@@ -23,11 +23,10 @@ export function tryOnScopeDispose(fn: () => void): boolean {
     return REGISTRY.tryOnScopeDisposeOverride(fn);
   }
 
-  const framework = globalThis.__UNUSE_FRAMEWORK__ as
-    | SupportedFramework
-    | undefined;
-
-  if (!framework) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const framework = (globalThis.__UNUSE_FRAMEWORK__ ||
+    'none') as SupportedFramework;
+  if (framework === 'none') {
     return false;
   }
 

--- a/packages/unuse/src/unAccess/index.ts
+++ b/packages/unuse/src/unAccess/index.ts
@@ -68,55 +68,56 @@ export function isUnRef<T>(value: unknown): value is UnRef<T> {
     return REGISTRY.isUnRefOverride(value);
   }
 
-  const framework = globalThis.__UNUSE_FRAMEWORK__ as
-    | SupportedFramework
-    | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const framework = (globalThis.__UNUSE_FRAMEWORK__ ||
+    'none') as SupportedFramework;
+  switch (framework) {
+    case 'angular': {
+      const Angular = importedFramework('angular');
 
-  if (framework) {
-    switch (framework) {
-      case 'angular': {
-        const Angular = importedFramework('angular');
-
-        if (Angular.isSignal(value)) {
-          return true;
-        }
-
-        break;
+      if (Angular.isSignal(value)) {
+        return true;
       }
 
-      case 'react': {
-        if (typeof value === 'object' && 'current' in value) {
-          return true;
-        }
+      break;
+    }
 
-        if (Array.isArray(value) && value.length > 0) {
-          return true;
-        }
-
-        break;
+    case 'react': {
+      if (typeof value === 'object' && 'current' in value) {
+        return true;
       }
 
-      case 'solid': {
-        if (typeof value === 'function') {
-          return true;
-        }
-
-        if (Array.isArray(value) && value.length > 0) {
-          return true;
-        }
-
-        break;
+      if (Array.isArray(value) && value.length > 0) {
+        return true;
       }
 
-      case 'vue': {
-        const Vue = importedFramework('vue');
+      break;
+    }
 
-        if (Vue.isRef(value)) {
-          return true;
-        }
-
-        break;
+    case 'solid': {
+      if (typeof value === 'function') {
+        return true;
       }
+
+      if (Array.isArray(value) && value.length > 0) {
+        return true;
+      }
+
+      break;
+    }
+
+    case 'vue': {
+      const Vue = importedFramework('vue');
+
+      if (Vue.isRef(value)) {
+        return true;
+      }
+
+      break;
+    }
+
+    case 'none': {
+      break;
     }
   }
 

--- a/packages/unuse/src/unRefElement/index.ts
+++ b/packages/unuse/src/unRefElement/index.ts
@@ -24,10 +24,9 @@ export function unRefElement<T extends MaybeElement>(
 ): UnRefElementReturn<T> {
   const plain = unAccess(elementRef);
 
-  const framework = globalThis.__UNUSE_FRAMEWORK__ as
-    | SupportedFramework
-    | undefined;
-
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const framework = (globalThis.__UNUSE_FRAMEWORK__ ||
+    'none') as SupportedFramework;
   if (framework === 'vue') {
     // @ts-expect-error: eat it
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-return

--- a/packages/unuse/src/unResolve/index.spec.ts
+++ b/packages/unuse/src/unResolve/index.spec.ts
@@ -12,7 +12,7 @@ describe('unResolve', () => {
     it('should resolve to an UnSignal', () => {
       const mySignal = unSignal(0);
 
-      const actual = unResolve(mySignal, { framework: undefined });
+      const actual = unResolve(mySignal, { framework: 'none' });
 
       expect(actual).toSatisfy(isUnSignal);
     });
@@ -20,7 +20,7 @@ describe('unResolve', () => {
     it('should update the UnSignal on change', () => {
       const mySignal = unSignal(0);
 
-      const actual = unResolve(mySignal, { framework: undefined });
+      const actual = unResolve(mySignal, { framework: 'none' });
 
       expect(actual.get()).toBe(0);
 
@@ -31,7 +31,7 @@ describe('unResolve', () => {
     it('should update back the original signal on change', () => {
       const mySignal = unSignal(0);
 
-      const actual = unResolve(mySignal, { framework: undefined });
+      const actual = unResolve(mySignal, { framework: 'none' });
 
       actual.set(100);
       expect(mySignal.get()).toBe(100);
@@ -41,7 +41,7 @@ describe('unResolve', () => {
       const mySignal = unSignal(0);
 
       const actual = unResolve(mySignal, {
-        framework: undefined,
+        framework: 'none',
         readonly: true,
       });
       expect(actual).toSatisfy(isUnComputed);

--- a/packages/unuse/src/unResolve/index.ts
+++ b/packages/unuse/src/unResolve/index.ts
@@ -16,9 +16,7 @@ import { unComputed } from '../unComputed';
 import type { UnSignal } from '../unSignal';
 
 export interface UnResolveOptions<
-  TFramework extends
-    | SupportedFramework
-    | undefined = typeof globalThis.__UNUSE_FRAMEWORK__,
+  TFramework extends SupportedFramework = typeof globalThis.__UNUSE_FRAMEWORK__,
   TReadonly extends boolean = false,
 > {
   /**
@@ -33,9 +31,7 @@ export interface UnResolveOptions<
 
 export type ReadonlyUnResolveReturn<
   T,
-  TFramework extends
-    | SupportedFramework
-    | undefined = typeof globalThis.__UNUSE_FRAMEWORK__,
+  TFramework extends SupportedFramework = typeof globalThis.__UNUSE_FRAMEWORK__,
 > = TFramework extends 'angular'
   ? AngularSignal<T>
   : TFramework extends 'react'
@@ -48,9 +44,7 @@ export type ReadonlyUnResolveReturn<
 
 export type WritableUnResolveReturn<
   T,
-  TFramework extends
-    | SupportedFramework
-    | undefined = typeof globalThis.__UNUSE_FRAMEWORK__,
+  TFramework extends SupportedFramework = typeof globalThis.__UNUSE_FRAMEWORK__,
 > = TFramework extends 'angular'
   ? AngularWritableSignal<T>
   : TFramework extends 'react'
@@ -63,9 +57,7 @@ export type WritableUnResolveReturn<
 
 export type UnResolveReturn<
   T,
-  TFramework extends
-    | SupportedFramework
-    | undefined = typeof globalThis.__UNUSE_FRAMEWORK__,
+  TFramework extends SupportedFramework = typeof globalThis.__UNUSE_FRAMEWORK__,
   TReadonly extends boolean = false,
 > = TReadonly extends true
   ? ReadonlyUnResolveReturn<T, TFramework>
@@ -93,9 +85,7 @@ export function overrideUnResolveFn(fn: typeof unResolve): void {
  */
 export function unResolve<
   T,
-  TFramework extends
-    | SupportedFramework
-    | undefined = typeof globalThis.__UNUSE_FRAMEWORK__,
+  TFramework extends SupportedFramework = typeof globalThis.__UNUSE_FRAMEWORK__,
   TReadonly extends boolean = false,
 >(
   signal: UnSignal<T>,
@@ -106,9 +96,9 @@ export function unResolve<
   }
 
   const {
-    framework = globalThis.__UNUSE_FRAMEWORK__ as
-      | SupportedFramework
-      | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    framework = (globalThis.__UNUSE_FRAMEWORK__ ||
+      'none') as SupportedFramework,
     readonly = false as boolean,
   } = options;
 


### PR DESCRIPTION
closes #32 

I'm not sure if this is a fix or feat 🤔 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added 'none' framework fallback to allow operation without a specific framework, updating behavior and tests accordingly.
> 
>   - **New Feature**:
>     - Added `'none'` as a `SupportedFramework` in `index.ts` to allow operation without a specific framework.
>     - Updated `initFrameworkImport()` and `importedFramework()` to exclude `'none'`.
>   - **Behavior Changes**:
>     - Default framework set to `'none'` in `toUnSignal()`, `tryOnScopeDispose()`, `unAccess()`, `unRefElement()`, and `unResolve()`.
>     - In `unResolve()`, added handling for `'none'` framework to return `UnSignal` or `UnComputed` based on `readonly` option.
>   - **Tests**:
>     - Updated `unResolve/index.spec.ts` to use `'none'` framework for testing `UnSignal` and `UnComputed` behavior.
>   - **Documentation**:
>     - Added changeset `thick-candles-doubt.md` documenting the new `'none'` framework feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 3ffae196181c024007bce5444016df8fe0e68d23. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a `'none'` framework fallback, allowing the library to operate without a specific framework.
- **Bug Fixes**
  - Improved handling of framework detection to ensure a default value is always set, preventing undefined behavior.
- **Tests**
  - Updated test cases to use the `'none'` framework option for more consistent testing.
- **Documentation**
  - Added a changeset documenting the new feature and related updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->