### PR TITLE
chore: cleanup

### DIFF
--- a/.changeset/dirty-buttons-open.md
+++ b/.changeset/dirty-buttons-open.md
@@ -6,4 +6,4 @@
 'unuse': patch
 ---
 
-fix!: remove internal override functions from public API
+fix: remove internal override functions from public API

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ You can find the core package at [packages/unuse](https://github.com/un-ts/unuse
 
 Framework-specific adapters are available for:
 
-- [unuse-angular](https://github.com/un-ts/unuse/tree/main/packages/unuse-angular)  
+- [unuse-angular](https://github.com/un-ts/unuse/tree/main/packages/unuse-angular)
   Support for [Angular](https://angular.dev), using `@angular/core`.
 
-- [unuse-react](https://github.com/un-ts/unuse/tree/main/packages/unuse-react)  
+- [unuse-react](https://github.com/un-ts/unuse/tree/main/packages/unuse-react)
   Support for [React](https://react.dev), using `react`.
 
 - [unuse-solid](https://github.com/un-ts/unuse/tree/main/packages/unuse-solid)


### PR DESCRIPTION
Before:

<img width="455" alt="image" src="https://github.com/user-attachments/assets/25be5e2c-a7c1-410d-b121-561a2f6ca13f" />

After:

<img width="539" alt="image" src="https://github.com/user-attachments/assets/2d595dd3-937e-48cb-8814-d4d302b12322" />

---

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove internal override functions from public API and clean up README.md formatting.
> 
>   - **Behavior**:
>     - Fix: Remove internal override functions from public API as noted in `.changeset/dirty-buttons-open.md`.
>   - **Documentation**:
>     - Remove trailing spaces in `README.md` for `unuse-angular` and `unuse-react` links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 3991bea96c6ce6eeb3ccc42d4c4f8a11c9372546. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->