### PR TITLE
chore: don't use `fixed` before v1.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
     }
   ],
   "commit": false,
-  "fixed": [["unuse", "unuse-*"]],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
This has been tested locally with `pnpm changeset version`

And the behavior when `fixed` is enabled could be an issue of `changeset`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration settings to remove fixed package grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->