### PR TITLE
chore: add cleanup script to remove target directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Monorepo for unuse packages",
   "scripts": {
-    "clean": "git clean -fdx",
+    "clean": "tsx scripts/clean.ts",
     "build": "pnpm -r build",
     "format": "prettier --cache --write .",
     "lint": "eslint --cache --cache-strategy content .",
@@ -66,6 +66,7 @@
     "prettier-plugin-pkg": "0.21.1",
     "publint": "0.3.12",
     "tsdown": "0.12.8",
+    "tsx": "^4.20.3",
     "typescript": "5.8.3",
     "typescript-eslint": "8.34.1",
     "unplugin-unused": "0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,10 @@ importers:
         version: 24.0.3
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
       '@vitest/eslint-plugin':
         specifier: 1.2.7
-        version: 1.2.7(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0))
+        version: 1.2.7(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
       eslint:
         specifier: 9.29.0
         version: 9.29.0(jiti@2.4.2)
@@ -83,6 +83,9 @@ importers:
       tsdown:
         specifier: 0.12.8
         version: 0.12.8(@arethetypeswrong/core@0.18.2)(publint@0.3.12)(typescript@5.8.3)(unplugin-unused@0.5.1)(vue-tsc@2.2.10(typescript@5.8.3))
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -94,7 +97,7 @@ importers:
         version: 0.5.1
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)
+        version: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
 
   docs:
     devDependencies:
@@ -134,7 +137,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: 20.0.3
-        version: 20.0.3(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(@angular/compiler@20.0.4)(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(@angular/platform-browser@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2)))(@types/node@24.0.3)(chokidar@4.0.3)(jiti@2.4.2)(postcss@8.5.6)(tslib@2.8.1)(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0))
+        version: 20.0.3(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(@angular/compiler@20.0.4)(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(@angular/platform-browser@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2)))(@types/node@24.0.3)(chokidar@4.0.3)(jiti@2.4.2)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.3)(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
       '@angular/cli':
         specifier: 20.0.3
         version: 20.0.3(@types/node@24.0.3)(chokidar@4.0.3)
@@ -162,10 +165,10 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: 4.5.2
-        version: 4.5.2(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))
+        version: 4.5.2(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
 
   examples/solid:
     dependencies:
@@ -178,10 +181,10 @@ importers:
     devDependencies:
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
       vite-plugin-solid:
         specifier: 2.11.6
-        version: 2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))
+        version: 2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
 
   examples/vue:
     dependencies:
@@ -194,10 +197,10 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 5.2.4
-        version: 5.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))(vue@3.5.17(typescript@5.8.3))
+        version: 5.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))(vue@3.5.17(typescript@5.8.3))
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
       vue-tsc:
         specifier: 2.2.10
         version: 2.2.10(typescript@5.8.3)
@@ -4322,6 +4325,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tuf-js@3.0.1:
     resolution: {integrity: sha512-+68OP1ZzSF84rTckf3FA95vJ1Zlx/uaXyiiKyPd1pA4rZNkpEvDAKmsu1xUSmbF/chCRYgZ6UZkDwC7PmzmAyA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4816,7 +4824,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@20.0.3(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(@angular/compiler@20.0.4)(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(@angular/platform-browser@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2)))(@types/node@24.0.3)(chokidar@4.0.3)(jiti@2.4.2)(postcss@8.5.6)(tslib@2.8.1)(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0))':
+  '@angular/build@20.0.3(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(@angular/compiler@20.0.4)(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(@angular/platform-browser@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2)))(@types/node@24.0.3)(chokidar@4.0.3)(jiti@2.4.2)(postcss@8.5.6)(tslib@2.8.1)(tsx@4.20.3)(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
@@ -4826,7 +4834,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.10(@types/node@24.0.3)
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
       beasties: 0.3.4
       browserslist: 4.25.0
       esbuild: 0.25.5
@@ -4846,14 +4854,14 @@ snapshots:
       tinyglobby: 0.2.13
       tslib: 2.8.1
       typescript: 5.8.3
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
       watchpack: 2.4.2
     optionalDependencies:
       '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2)
       '@angular/platform-browser': 20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.2))
       lmdb: 3.3.0
       postcss: 8.5.6
-      vitest: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)
+      vitest: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -6515,11 +6523,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.9.1':
     optional: true
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))':
     dependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
 
-  '@vitejs/plugin-react@4.5.2(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))':
+  '@vitejs/plugin-react@4.5.2(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.4)
@@ -6527,7 +6535,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.11
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6536,12 +6544,12 @@ snapshots:
       vite: 5.4.19(@types/node@24.0.3)(sass@1.88.0)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6556,17 +6564,17 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)
+      vitest: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.2.7(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0))':
+  '@vitest/eslint-plugin@1.2.7(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))':
     dependencies:
       '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)
+      vitest: 3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6578,13 +6586,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8760,6 +8768,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tuf-js@3.0.1:
     dependencies:
       '@tufjs/models': 3.0.1
@@ -8900,13 +8915,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0):
+  vite-node@3.2.4(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8921,7 +8936,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)):
+  vite-plugin-solid@2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)):
     dependencies:
       '@babel/core': 7.27.4
       '@types/babel__core': 7.20.5
@@ -8929,8 +8944,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.7
       solid-refresh: 0.6.3(solid-js@1.9.7)
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
-      vitefu: 1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
+      vitefu: 1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -8944,7 +8959,7 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.88.0
 
-  vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0):
+  vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -8957,10 +8972,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       sass: 1.88.0
+      tsx: 4.20.3
 
-  vitefu@1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)):
+  vitefu@1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
 
   vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@24.0.3)(postcss@8.5.6)(sass@1.88.0)(search-insights@2.17.3)(typescript@5.8.3):
     dependencies:
@@ -9011,11 +9027,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0):
+  vitest@3.2.4(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9033,8 +9049,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
-      vite-node: 3.2.4(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
+      vite-node: 3.2.4(@types/node@24.0.3)(jiti@2.4.2)(sass@1.88.0)(tsx@4.20.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.3

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -1,0 +1,59 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+const rootDir = process.cwd();
+
+/**
+ * Recursively find and delete target directories
+ * @param {string} currentDir - The current directory path being traversed
+ */
+async function cleanTargetsRecursively(
+  currentDir: string,
+  targets: string | string[]
+) {
+  const items = await fs.readdir(currentDir);
+
+  for (const item of items) {
+    try {
+      const itemPath = join(currentDir, item);
+      if (targets.includes(item)) {
+        // Delete directly when target directory or file is matched
+        await fs.rm(itemPath, { force: true, recursive: true });
+        console.log(`Deleted: ${itemPath}`);
+      }
+
+      const stat = await fs.lstat(itemPath);
+      if (stat.isDirectory()) {
+        await cleanTargetsRecursively(itemPath, targets);
+      }
+    } catch {
+      // console.error(
+      //   `Error handling item ${item} in ${currentDir}: ${error.message}`,
+      // );
+    }
+  }
+}
+
+await (async function startCleanup() {
+  // Directory and file names to be deleted
+  const targets = ['node_modules', 'dist'];
+
+  const deleteLockFile = process.argv.includes('--del-lock');
+  const cleanupTargets = [...targets];
+  if (deleteLockFile) {
+    cleanupTargets.push('pnpm-lock.yaml');
+  }
+
+  console.log(
+    `Starting cleanup of targets: ${cleanupTargets.join(', ')} from root: ${rootDir}`
+  );
+
+  try {
+    await cleanTargetsRecursively(rootDir, cleanupTargets);
+    console.log('Cleanup process completed.');
+  } catch (error) {
+    console.error(
+      `Unexpected error during cleanup: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+})();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `clean` script with a new TypeScript-based cleanup script for more controlled directory and file removal.
> 
>   - **Scripts**:
>     - Replaces `clean` script in `package.json` from `git clean -fdx` to `tsx scripts/clean.ts`.
>     - Adds `tsx` as a dev dependency in `package.json`.
>   - **Functionality**:
>     - New script `clean.ts` recursively deletes `node_modules` and `dist` directories.
>     - Supports optional deletion of `pnpm-lock.yaml` if `--del-lock` argument is provided.
>     - Logs each deletion and handles errors silently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 5150df72b2b879e71953d437a2d3c12fe5106251. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the cleanup process to use an automated script for removing build artifacts and dependencies.
	- Added a new tool to support running TypeScript scripts during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->