### PR TITLE
chore: fix test linting

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -188,13 +188,13 @@ export default defineConfig(
 
   //#region overrides
   {
-    name: '**/test/**/*.ts overrides',
-    files: ['**/test/**/*.spec.ts', '**/test/**/*.spec.d.ts'],
+    name: '**/*.spec.ts overrides',
+    files: ['**/*.spec.ts', '**/*.spec.d.ts'],
     plugins: {
       vitest: eslintPluginVitest,
     },
     rules: {
-      'deprecation/deprecation': 'off',
+      '@typescript-eslint/no-deprecated': 'off',
 
       '@typescript-eslint/restrict-template-expressions': [
         'error',
@@ -212,6 +212,7 @@ export default defineConfig(
       'vitest/prefer-each': 'error',
       'vitest/prefer-to-have-length': 'error',
       'vitest/valid-expect': ['error', { maxArgs: 2 }],
+      'vitest/warn-todo': 'warn',
     },
     settings: {
       vitest: {

--- a/packages/unuse/src/useEventListener/index.vue.spec.ts
+++ b/packages/unuse/src/useEventListener/index.vue.spec.ts
@@ -28,22 +28,22 @@ describeVue('useEventListener', () => {
     });
 
     it('should add listener', () => {
-      expect(addSpy).toBeCalledTimes(1);
+      expect(addSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should trigger listener', () => {
-      expect(listener).not.toBeCalled();
+      expect(listener).not.toHaveBeenCalled();
       target.dispatchEvent(new MouseEvent(event));
-      expect(listener).toBeCalledTimes(1);
+      expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('should remove listener', () => {
-      expect(removeSpy).not.toBeCalled();
+      expect(removeSpy).not.toHaveBeenCalled();
 
       stop();
 
-      expect(removeSpy).toBeCalledTimes(1);
-      expect(removeSpy).toBeCalledWith(event, listener, options);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(event, listener, options);
     });
   });
 });

--- a/packages/unuse/src/useWebSocket/index.vue.spec.ts
+++ b/packages/unuse/src/useWebSocket/index.vue.spec.ts
@@ -33,7 +33,7 @@ describeVue('useWebSocket', () => {
     expect((vm.ref.status as unknown as Ref<WebSocketStatus>).value).toBe(
       'CONNECTING'
     );
-    expect(mockWebSocket).toBeCalledWith('ws://localhost', []);
+    expect(mockWebSocket).toHaveBeenCalledWith('ws://localhost', []);
     expect(vm.ref.close).toBeTypeOf('function');
     expect(vm.ref.send).toBeTypeOf('function');
     expect(vm.ref.open).toBeTypeOf('function');


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix test linting by updating ESLint configurations and test assertions for consistency and readability.
> 
>   - **ESLint Configuration**:
>     - Update `eslint.config.ts` to change `files` pattern from `**/test/**/*.spec.ts` to `**/*.spec.ts`.
>     - Replace deprecated rule `deprecation/deprecation` with `@typescript-eslint/no-deprecated`.
>     - Add `vitest/warn-todo` rule set to `warn`.
>   - **Test Files**:
>     - In `index.vue.spec.ts` and `index.vue.spec.ts`, replace `toBeCalledTimes` with `toHaveBeenCalledTimes` and `not.toBeCalled` with `not.toHaveBeenCalled` for better readability and consistency.
>     - Update `mockWebSocket` assertion in `index.vue.spec.ts` to use `toHaveBeenCalledWith`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 93615fbbc58020cc9946bd81230838a8394c615a. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated test assertion methods to use more explicit and consistent matchers for improved clarity in test output.

* **Chores**
  * Broadened ESLint test file matching patterns and updated override naming.
  * Adjusted ESLint rules to use updated plugin rule names and added a warning for unfinished Vitest tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->