### PR TITLE
feat: add signal peek

### DIFF
--- a/.changeset/dark-rats-ask.md
+++ b/.changeset/dark-rats-ask.md
@@ -1,0 +1,10 @@
+---
+'unuse-reactivity': minor
+'unuse': minor
+'unuse-angular': minor
+'unuse-react': minor
+'unuse-solid': minor
+'unuse-vue': minor
+---
+
+feat: add signal peek

--- a/packages/unuse-reactivity/src/unComputed/index.ts
+++ b/packages/unuse-reactivity/src/unComputed/index.ts
@@ -54,6 +54,7 @@ export const UN_COMPUTED = Symbol('UN_COMPUTED');
  */
 export interface UnComputed<T> {
   readonly [UN_COMPUTED]: true;
+
   /**
    * Retrieves the current value of the computed.
    */

--- a/packages/unuse-reactivity/src/unSignal/index.spec.ts
+++ b/packages/unuse-reactivity/src/unSignal/index.spec.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { isUnSignal, UN_SIGNAL, unSignal } from '.';
+import { unEffect } from '../unEffect';
 
 describe('unSignal', () => {
   it('should be defined', () => {
@@ -12,6 +13,7 @@ describe('unSignal', () => {
 
     expect(mySignal).toBeTypeOf('object');
     expect(mySignal.get).toBeTypeOf('function');
+    expect(mySignal.peek).toBeTypeOf('function');
     expect(mySignal.set).toBeTypeOf('function');
     expect(mySignal.update).toBeTypeOf('function');
     expect(isUnSignal(mySignal)).toBe(true);
@@ -22,6 +24,7 @@ describe('unSignal', () => {
 
     expect(mySignal).toBeTypeOf('object');
     expect(mySignal.get).toBeTypeOf('function');
+    expect(mySignal.peek).toBeTypeOf('function');
     expect(mySignal.set).toBeTypeOf('function');
     expect(mySignal.update).toBeTypeOf('function');
     expect(isUnSignal(mySignal)).toBe(true);
@@ -49,6 +52,52 @@ describe('unSignal', () => {
     mySignal.update((prev) => prev * 2); // 20
     mySignal.update((prev) => prev + 5); // 25
     expect(mySignal.get()).toBe(25);
+  });
+
+  it('should trigger unEffect on set', () => {
+    const fn1Spy = vi.fn();
+
+    const mySignal = unSignal(42);
+
+    unEffect(() => {
+      mySignal.get();
+      fn1Spy();
+    });
+
+    mySignal.set(100);
+
+    expect(fn1Spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should trigger unEffect on update', () => {
+    const fn1Spy = vi.fn();
+
+    const mySignal = unSignal(42);
+
+    unEffect(() => {
+      mySignal.get();
+      fn1Spy();
+    });
+
+    mySignal.update((prev) => prev + 10);
+
+    expect(fn1Spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should peek the current value without triggering effects', () => {
+    const fn1Spy = vi.fn();
+
+    const mySignal = unSignal(42);
+
+    unEffect(() => {
+      mySignal.peek();
+      fn1Spy();
+    });
+
+    mySignal.set(100);
+    expect(mySignal.peek()).toBe(100);
+
+    expect(fn1Spy).toHaveBeenCalledTimes(1);
   });
 
   describe('isUnSignal', () => {
@@ -83,6 +132,7 @@ describe('unSignal', () => {
       const obj = {
         [UN_SIGNAL]: false,
         get: () => 42,
+        peek: () => 42,
         set: () => {},
         update: () => {},
       };
@@ -100,6 +150,7 @@ describe('unSignal', () => {
       const obj = {
         [UN_SIGNAL]: true,
         get: () => 42,
+        peek: () => 42,
         set: () => {},
         update: () => {},
       };

--- a/packages/unuse-reactivity/src/unSignal/index.ts
+++ b/packages/unuse-reactivity/src/unSignal/index.ts
@@ -36,6 +36,11 @@ export interface UnSignal<T> {
   get(): T;
 
   /**
+   * Retrieves the current value of the signal without triggering effects.
+   */
+  peek(): T;
+
+  /**
    * Sets a new value for the signal.
    */
   set(value: T): void;
@@ -97,6 +102,7 @@ export function unSignal<T>(initialValue?: T): UnSignal<T> {
 
       return value;
     },
+    peek: () => state.value,
     set: setter,
     update: (updater) => {
       setter(updater(state.value));
@@ -115,6 +121,7 @@ export function isUnSignal<T>(value: unknown): value is UnSignal<T> {
     UN_SIGNAL in value &&
     value[UN_SIGNAL] === true &&
     typeof (value as UnSignal<T>).get === 'function' &&
+    typeof (value as UnSignal<T>).peek === 'function' &&
     typeof (value as UnSignal<T>).set === 'function' &&
     typeof (value as UnSignal<T>).update === 'function'
   );


### PR DESCRIPTION
adds the `peek` function to unSignal ~~and unComputed~~

taken from https://github.com/un-ts/unuse/pull/27

this can later be used to retrieve a value without triggering inside an effect

I added @teleskop150750 so he gets credits for it and the next PRs from him can CI-run without approvals
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `peek()` method to `UnSignal` for non-reactive value access, with tests in `index.spec.ts`.
> 
>   - **New Features**:
>     - Added `peek()` method to `UnSignal` in `index.ts` to access current signal value without triggering effects.
>   - **Tests**:
>     - Updated `index.spec.ts` to include tests for `peek()` method, ensuring non-reactive access pattern.
>   - **Misc**:
>     - Minor formatting change in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for b3c37329fd2d2f44bcb208814a1a15ae0d914de7. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new peek() method for signals, allowing users to access the current signal value without triggering reactive effects.

* **Tests**
  * Added tests to verify the behavior of the new peek() method and its non-reactive access pattern for signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->