### PR TITLE
chore: fix test descriptions

### DIFF
--- a/packages/unuse-angular/src/index.spec.ts
+++ b/packages/unuse-angular/src/index.spec.ts
@@ -90,7 +90,7 @@ describe('unuse-angular', () => {
       expect(resolved()).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+    it('should resolve an UnSignal to an UnSignal when framework is none', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, { framework: 'none' });
 
@@ -98,7 +98,7 @@ describe('unuse-angular', () => {
       expect(resolved.get()).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+    it('should resolve an UnSignal to an UnComputed when framework is none and readonly is true', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, {
         framework: 'none',

--- a/packages/unuse-react/src/index.spec.ts
+++ b/packages/unuse-react/src/index.spec.ts
@@ -87,7 +87,7 @@ describe('unuse-react', () => {
       expect(hook.result.current).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+    it('should resolve an UnSignal to an UnSignal when framework is none', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, { framework: 'none' });
 
@@ -95,7 +95,7 @@ describe('unuse-react', () => {
       expect(resolved.get()).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+    it('should resolve an UnSignal to an UnComputed when framework is none and readonly is true', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, {
         framework: 'none',

--- a/packages/unuse-solid/src/index.spec.ts
+++ b/packages/unuse-solid/src/index.spec.ts
@@ -72,7 +72,7 @@ describe('unuse-solid', () => {
       expect(resolved()).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+    it('should resolve an UnSignal to an UnSignal when framework is none', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, { framework: 'none' });
 
@@ -80,7 +80,7 @@ describe('unuse-solid', () => {
       expect(resolved.get()).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+    it('should resolve an UnSignal to an UnComputed when framework is none and readonly is true', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, {
         framework: 'none',

--- a/packages/unuse-vue/src/index.spec.ts
+++ b/packages/unuse-vue/src/index.spec.ts
@@ -93,7 +93,7 @@ describe('unuse-vue', () => {
       expect(resolved.value).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnSignal when framework is null', () => {
+    it('should resolve an UnSignal to an UnSignal when framework is none', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, { framework: 'none' });
 
@@ -101,7 +101,7 @@ describe('unuse-vue', () => {
       expect(resolved.get()).toBe(42);
     });
 
-    it('should resolve an UnSignal to an UnComputed when framework is null and readonly is true', () => {
+    it('should resolve an UnSignal to an UnComputed when framework is none and readonly is true', () => {
       const mySignal = unSignal(42);
       const resolved = unResolve(mySignal, {
         framework: 'none',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix test descriptions in `index.spec.ts` for Angular, React, Solid, and Vue by changing 'framework is null' to 'framework is none'.
> 
>   - **Test Descriptions**:
>     - Change 'framework is null' to 'framework is none' in test descriptions in `index.spec.ts` for Angular, React, Solid, and Vue.
>     - Affects tests for `unResolve` function when framework is 'none'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 83ad59929043f3f3ffd304508e9adeef539ca97e. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test descriptions to use "none" instead of "null" when referring to the framework option in multiple test suites. Test logic and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->