### PR TITLE
infra: use merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: Coverage
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   # Required to checkout the code

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - edited
       - synchronize
+  merge_group:
 
 permissions: {}
 
@@ -22,6 +23,7 @@ jobs:
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        if: ${{ github.event_name == 'pull_request_target' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `merge_group` trigger to multiple GitHub Actions workflows to support merge group events.
> 
>   - **Workflows**:
>     - Add `merge_group` trigger to `ci.yml`, `coverage.yml`, `playwright.yml`, and `semantic-pull-request.yml` to enable workflows to run on merge group events.
>   - **Semantic Pull Request**:
>     - Add condition `if: ${{ github.event_name == 'pull_request_target' }}` to the `Validate PR title` step in `semantic-pull-request.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 10f5ca44b1dfaf5dc40adf3efa076d59e67d5a9b. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration, coverage, and Playwright workflows to also run on merge group events.
  * Enhanced the semantic pull request workflow to support merge group events and refined validation logic to run only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->