### PR TITLE
test: useIntervalFn

### DIFF
--- a/packages/unuse/src/useIntervalFn/index.solid.spec.ts
+++ b/packages/unuse/src/useIntervalFn/index.solid.spec.ts
@@ -1,0 +1,47 @@
+import type { Accessor } from 'solid-js';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { useIntervalFn } from '.';
+import { describeSolid } from '../_testUtils/solid';
+
+describeSolid('useIntervalFn', () => {
+  let callback = vi.fn();
+  vi.useFakeTimers();
+
+  beforeEach(() => {
+    callback = vi.fn();
+  });
+
+  it('pause in callback', async () => {
+    const pausable = useIntervalFn(
+      () => {
+        callback();
+        pausable.pause();
+      },
+      50,
+      { immediateCallback: true, immediate: false }
+    );
+
+    pausable.resume();
+    expect(pausable.isActive).toSatisfy((value) => typeof value === 'function');
+    expect((pausable.isActive as Accessor<boolean>)()).toBeFalsy();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    pausable.resume();
+    expect((pausable.isActive as Accessor<boolean>)()).toBeFalsy();
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('cant work when interval is negative', async () => {
+    const { isActive } = useIntervalFn(callback, -1);
+
+    expect((isActive as Accessor<boolean>)()).toBeFalsy();
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/unuse/src/useIntervalFn/index.spec.ts
+++ b/packages/unuse/src/useIntervalFn/index.spec.ts
@@ -1,8 +1,93 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment happy-dom
+
+import type { UnComputed } from 'unuse-reactivity';
+import { isUnComputed, unSignal } from 'unuse-reactivity';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Pausable } from '.';
 import { useIntervalFn } from '.';
 
 describe('useIntervalFn', () => {
   it('should be defined', () => {
     expect(useIntervalFn).toBeTypeOf('function');
+  });
+
+  let callback = vi.fn();
+  vi.useFakeTimers();
+
+  beforeEach(() => {
+    callback = vi.fn();
+  });
+
+  async function exec({ isActive, pause, resume }: Pausable) {
+    expect(isActive).toSatisfy(isUnComputed);
+    expect((isActive as unknown as UnComputed<boolean>).get()).toBeTruthy();
+    expect(callback).toHaveBeenCalledTimes(0);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    pause();
+    expect((isActive as unknown as UnComputed<boolean>).get()).toBeFalsy();
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    resume();
+    expect((isActive as unknown as UnComputed<boolean>).get()).toBeTruthy();
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(2);
+  }
+
+  it('basic pause/resume', async () => {
+    await exec(useIntervalFn(callback, 50));
+
+    callback = vi.fn();
+
+    const interval = unSignal(50);
+    await exec(useIntervalFn(callback, interval));
+
+    callback.mockClear();
+    interval.set(20);
+    await vi.advanceTimersByTimeAsync(30);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('pause in callback', async () => {
+    const pausable = useIntervalFn(
+      () => {
+        callback();
+        pausable.pause();
+      },
+      50,
+      { immediateCallback: true, immediate: false }
+    );
+
+    pausable.resume();
+    expect(pausable.isActive).toSatisfy(isUnComputed);
+    expect(
+      (pausable.isActive as unknown as UnComputed<boolean>).get()
+    ).toBeFalsy();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    pausable.resume();
+    expect(
+      (pausable.isActive as unknown as UnComputed<boolean>).get()
+    ).toBeFalsy();
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('cant work when interval is negative', async () => {
+    const { isActive } = useIntervalFn(callback, -1);
+
+    expect((isActive as unknown as UnComputed<boolean>).get()).toBeFalsy();
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/unuse/src/useIntervalFn/index.vue.spec.ts
+++ b/packages/unuse/src/useIntervalFn/index.vue.spec.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, expect, it, vi } from 'vitest';
 import type { Ref } from 'vue';
-import { isRef, shallowRef } from 'vue';
+import { effectScope, isRef, nextTick, shallowRef } from 'vue';
 import type { Pausable } from '.';
 import { useIntervalFn } from '.';
 import { describeVue } from '../_testUtils/vue';
@@ -36,6 +36,28 @@ describeVue('useIntervalFn', () => {
     expect(callback).toHaveBeenCalledTimes(2);
   }
 
+  async function execImmediateCallback({ isActive, pause, resume }: Pausable) {
+    expect(isActive).toSatisfy(isRef);
+    expect((isActive as unknown as Ref<boolean>).value).toBeTruthy();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    pause();
+    expect((isActive as unknown as Ref<boolean>).value).toBeFalsy();
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    resume();
+    expect((isActive as unknown as Ref<boolean>).value).toBeTruthy();
+    expect(callback).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(4);
+  }
+
   it('basic pause/resume', async () => {
     await exec(useIntervalFn(callback, 50));
 
@@ -48,5 +70,68 @@ describeVue('useIntervalFn', () => {
     interval.value = 20;
     await vi.advanceTimersByTimeAsync(30);
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('pause/resume with immediateCallback', async () => {
+    await execImmediateCallback(
+      useIntervalFn(callback, 50, { immediateCallback: true })
+    );
+
+    callback = vi.fn();
+
+    const interval = shallowRef(50);
+    await execImmediateCallback(
+      useIntervalFn(callback, interval, { immediateCallback: true })
+    );
+
+    callback.mockClear();
+    interval.value = 20;
+    await nextTick();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('pause/resume in scope', async () => {
+    const scope = effectScope();
+    await scope.run(async () => {
+      await exec(useIntervalFn(callback, 50));
+    });
+    callback.mockClear();
+    scope.stop();
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+
+  it('pause in callback', async () => {
+    const pausable = useIntervalFn(
+      () => {
+        callback();
+        pausable.pause();
+      },
+      50,
+      { immediateCallback: true, immediate: false }
+    );
+
+    pausable.resume();
+    expect(pausable.isActive).toSatisfy(isRef);
+    expect((pausable.isActive as unknown as Ref<boolean>).value).toBeFalsy();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    pausable.resume();
+    expect((pausable.isActive as unknown as Ref<boolean>).value).toBeFalsy();
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('cant work when interval is negative', async () => {
+    const { isActive } = useIntervalFn(callback, -1);
+
+    expect((isActive as unknown as Ref<boolean>).value).toBeFalsy();
+    await vi.advanceTimersByTimeAsync(60);
+    expect(callback).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
this is theoretically a copy of #12, but only with tests that runs successfully

- #12 

it aims to reduce the diff of #12 and I still hope that someone in the community can jump in and help us finding out why things are not working as expected
there is something fundamentally basic that stops this library of being used in production 🥲 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tests for `useIntervalFn` in Solid, Vue, and generic environments to cover pause/resume, immediate callback, and negative interval scenarios.
> 
>   - **Tests Added**:
>     - `index.solid.spec.ts`: Tests `useIntervalFn` in Solid environment, covering pause in callback and negative interval scenarios.
>     - `index.spec.ts`: Tests `useIntervalFn` in a generic environment, including basic pause/resume, pause in callback, and negative interval scenarios.
>     - `index.vue.spec.ts`: Tests `useIntervalFn` in Vue environment, covering basic pause/resume, immediate callback, scope handling, and negative interval scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for 8846459558e2ef6b5c5e15bd39de51c33b00b057. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added and expanded test coverage for the interval functionality across Solid, Vue, and core environments.
  * Introduced new tests for pause/resume behavior, immediate callback execution, dynamic interval changes, and handling of negative intervals.
  * Enhanced verification of active state and callback invocations, including edge cases and effect scope scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->