### PR TITLE
test: increase reactivity coverage

### DIFF
--- a/packages/unuse-reactivity/src/index.spec.ts
+++ b/packages/unuse-reactivity/src/index.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isUnComputed,
+  isUnSignal,
+  unComputed,
+  unEffect,
+  unEffectScope,
+  unSignal,
+  unWatch,
+} from '.';
+
+describe('unuse-reactivity', () => {
+  it('should expose reactivity functions', () => {
+    expect(isUnComputed).toBeTypeOf('function');
+    expect(isUnSignal).toBeTypeOf('function');
+    expect(unComputed).toBeTypeOf('function');
+    expect(unEffect).toBeTypeOf('function');
+    expect(unEffectScope).toBeTypeOf('function');
+    expect(unSignal).toBeTypeOf('function');
+    expect(unWatch).toBeTypeOf('function');
+  });
+});

--- a/packages/unuse-reactivity/src/unEffect/index.spec.ts
+++ b/packages/unuse-reactivity/src/unEffect/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { unEffect } from '.';
+import { getCurrentSub } from '../unReactiveSystem';
 import { unSignal } from '../unSignal';
 
 describe('unEffect', () => {
@@ -43,5 +44,24 @@ describe('unEffect', () => {
 
     source.set(2);
     expect(fnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should trigger in current sub', () => {
+    const source = unSignal(0);
+
+    expect(getCurrentSub()).toBeUndefined();
+
+    unEffect(() => {
+      const outerSub = getCurrentSub();
+      expect(outerSub).toBeDefined();
+
+      unEffect(() => {
+        const innerSub = getCurrentSub();
+        expect(innerSub).toBeDefined();
+        expect(innerSub).not.toBe(outerSub);
+
+        source.get();
+      });
+    });
   });
 });

--- a/packages/unuse-reactivity/src/unEffectScope/index.spec.ts
+++ b/packages/unuse-reactivity/src/unEffectScope/index.spec.ts
@@ -1,8 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { unEffectScope } from '.';
+import { getCurrentScope } from '../unReactiveSystem';
 
 describe('unEffectScope', () => {
   it('should be defined', () => {
     expect(unEffectScope).toBeTypeOf('function');
+  });
+
+  it('should return the cleanup function', () => {
+    const actual = unEffectScope(() => {});
+    expect(actual).toBeTypeOf('function');
+  });
+
+  it('should execute the effect function', () => {
+    const fnSpy = vi.fn();
+    unEffectScope(fnSpy);
+    expect(fnSpy).toHaveBeenCalled();
+  });
+
+  it('should set the current scope', () => {
+    expect(getCurrentScope()).toBeUndefined();
+
+    unEffectScope(() => {
+      const outerScope = getCurrentScope();
+      expect(outerScope).toBeDefined();
+
+      unEffectScope(() => {
+        const innerScope = getCurrentScope();
+
+        expect(innerScope).toBeDefined();
+        expect(innerScope).not.toBe(outerScope);
+      });
+    });
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add comprehensive test coverage for `unuse-reactivity` package functions, ensuring correct behavior and scope management.
> 
>   - **Tests**:
>     - Add `index.spec.ts` to test exposure of reactivity functions like `isUnComputed`, `unComputed`, `unEffect`, etc.
>     - Enhance `unComputed/index.spec.ts` with tests for scope linking, dirty updates, and `isUnComputed` behavior.
>     - Add tests in `unEffect/index.spec.ts` for immediate execution, disposal, and sub-triggering.
>     - Add tests in `unEffectScope/index.spec.ts` for cleanup function, effect execution, and scope setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Funuse&utm_source=github&utm_medium=referral)<sup> for c90fba467ebd725fecda0f0e2ee5f33f0d20f189. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test suites to verify that all main reactivity functions are properly exported and defined.
  * Expanded tests for computed values to check scope linkage and internal state updates when signals change.
  * Added tests for effect subscriptions to ensure correct behavior in nested contexts.
  * Enhanced effect scope tests to validate cleanup, execution, and proper management of nested scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->